### PR TITLE
Fix ScalaJS client setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean test it:compile
+  - sbt ++$TRAVIS_SCALA_VERSION clean test
   - sbt "project sharedJS" "fastOptJS"
-  - sbt "project http4s-clientJS" "fastOptJS"
+  - sbt "project js-client" "fastOptJS"

--- a/build.sbt
+++ b/build.sbt
@@ -93,11 +93,12 @@ lazy val typedapi = project
     `client-js`, 
     `client-jvm`, 
     server, 
-    `http4s-client-js`, 
-    `http4s-client-jvm` , 
+    `http4s-client`, 
     `http4s-server`, 
     `akka-http-client`,
-    `akka-http-server`
+    `akka-http-server`,
+    `js-client`,
+    `http-support-tests`
   )
 
 lazy val shared = crossProject.crossType(CrossType.Pure)
@@ -136,30 +137,23 @@ lazy val server = project
   .dependsOn(`shared-jvm`)
 
 
-lazy val `http4s-client` = crossProject.crossType(CrossType.Pure)
+lazy val `http4s-client` = project
   .in(file("http4s-client"))
-  .configs(IntegrationTest)
   .settings(
     commonSettings,
     mavenSettings,
-    Defaults.itSettings,
     name := "typedapi-http4s-client",
     libraryDependencies ++= Dependencies.http4sClient,
 
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
-  .dependsOn(client)
-
-lazy val `http4s-client-js` = `http4s-client`.js
-lazy val `http4s-client-jvm` = `http4s-client`.jvm
+  .dependsOn(`client-jvm`)
 
 lazy val `http4s-server` = project
   .in(file("http4s-server"))
-  .configs(IntegrationTest)
   .settings(
     commonSettings,
     mavenSettings,
-    Defaults.itSettings,
     name := "typedapi-http4s-server",
     libraryDependencies ++= Dependencies.http4sServer,
 
@@ -173,9 +167,7 @@ lazy val `akka-http-client` = project
     commonSettings,
     mavenSettings,
     name := "typedapi-akka-http-client",
-    libraryDependencies ++= Dependencies.akkaHttpClient,
-
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    libraryDependencies ++= Dependencies.akkaHttpClient
   )
   .dependsOn(`client-jvm`)
 
@@ -185,19 +177,28 @@ lazy val `akka-http-server` = project
     commonSettings,
     mavenSettings,
     name := "typedapi-akka-http-server",
-    libraryDependencies ++= Dependencies.akkaHttpServer,
-
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    libraryDependencies ++= Dependencies.akkaHttpServer
   )
   .dependsOn(server)
+
+lazy val `js-client` = project
+  .in(file("js-client"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    commonSettings,
+    mavenSettings,
+    name := "typedapi-js-client",
+    libraryDependencies ++= Seq(
+      "org.scala-js" %%% "scalajs-dom" % "0.9.6" % Compile
+    )
+  )
+  .dependsOn(`client-js`)
 
 lazy val `http-support-tests` = project
   .in(file("http-support-tests"))
   .settings(
     commonSettings,
     parallelExecution in Test := false,
-    libraryDependencies ++= Dependencies.httpSupportTests,
-
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    libraryDependencies ++= Dependencies.httpSupportTests
   )
-  .dependsOn(`http4s-client-jvm`, `http4s-server`, `akka-http-client`, `akka-http-server`)
+  .dependsOn(`http4s-client`, `http4s-server`, `akka-http-client`, `akka-http-server`)

--- a/http-support-tests/src/test/scala/http/support/tests/User.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/User.scala
@@ -1,13 +1,16 @@
 package http.support.tests
 
 import cats.effect.IO
-import io.circe.generic.JsonCodec
+import io.circe.generic.semiauto._
 import org.http4s.circe._
 import org.http4s.dsl.io._
 
-@JsonCodec case class User(name: String, age: Int)
+final case class User(name: String, age: Int)
 
 object UserCoding {
+
+  implicit val enc = deriveEncoder[User]
+  implicit val dec = deriveDecoder[User]
 
   implicit val decoderIO = jsonOf[IO, User]
   implicit val encoderIO = jsonEncoderOf[IO, User]

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -1,6 +1,6 @@
 package http.support.tests.client
 
-import http.support.tests.{User, Api}
+import http.support.tests.{User, UserCoding, Api}
 import typedapi.client._
 import typedapi.client.akkahttp._
 import akka.actor.ActorSystem
@@ -15,6 +15,7 @@ import scala.concurrent.{Future, Await}
 
 final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specification {
 
+  import UserCoding._
   import FailFastCirceSupport._
 
   sequential

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -1,6 +1,6 @@
 package http.support.tests.server
 
-import http.support.tests.Api
+import http.support.tests.{Api, UserCoding}
 import typedapi.server._
 import typedapi.server.akkahttp._
 import akka.actor.ActorSystem
@@ -15,6 +15,7 @@ import scala.concurrent.duration._
 
 final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerSupportSpec[Future]()(catsStdInstancesForFuture(ee.ec)) {
 
+  import UserCoding._
   import FailFastCirceSupport._
 
   implicit val timeout = 1.second

--- a/js-client/src/main/scala/typedapi/client/js/Decoder.scala
+++ b/js-client/src/main/scala/typedapi/client/js/Decoder.scala
@@ -1,0 +1,12 @@
+package typedapi.client.js
+
+import scala.concurrent.Future
+
+trait Decoder[A] extends (String => Future[A])
+
+object Decoder {
+
+  def apply[A](decoder: String => Future[A]): Decoder[A] = new Decoder[A] {
+    def apply(raw: String): Future[A] = decoder(raw)
+  }
+}

--- a/js-client/src/main/scala/typedapi/client/js/Encoder.scala
+++ b/js-client/src/main/scala/typedapi/client/js/Encoder.scala
@@ -1,0 +1,10 @@
+package typedapi.client.js
+
+trait Encoder[A] extends (A => String)
+
+object Encoder {
+
+  def apply[A](encoder: A => String): Encoder[A] = new Encoder[A] {
+    def apply(a: A): String = encoder(a)
+  }
+}

--- a/js-client/src/main/scala/typedapi/client/js/package.scala
+++ b/js-client/src/main/scala/typedapi/client/js/package.scala
@@ -1,0 +1,81 @@
+package typedapi.client
+
+import org.scalajs.dom.ext.Ajax
+
+import scala.concurrent.{Future, ExecutionContext}
+
+package object js {
+
+  private def renderQueries(queries: Map[String, List[String]]): String = 
+    queries
+      .map { case (key, values) => s"$key=${values.mkString(",")}" }
+      .mkString("?", "&", "")
+
+  implicit def getRequest[A](implicit decoder: Decoder[A], ec: ExecutionContext) = new GetRequest[Ajax.type, Future, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .get(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+
+  implicit def putRequest[A](implicit decoder: Decoder[A], ec: ExecutionContext) = new PutRequest[Ajax.type, Future, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .put(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+
+  implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Bd], decoder: Decoder[A], ec: ExecutionContext) = new PutWithBodyRequest[Ajax.type, Future, Bd, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .put(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers,
+          data    = encoder(body)
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+
+  implicit def postRequest[A](implicit decoder: Decoder[A], ec: ExecutionContext) = new PostRequest[Ajax.type, Future, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .post(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+
+  implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Bd], decoder: Decoder[A], ec: ExecutionContext) = new PostWithBodyRequest[Ajax.type, Future, Bd, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .post(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers,
+          data    = encoder(body)
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+
+  implicit def deleteRequest[A](implicit decoder: Decoder[A], ec: ExecutionContext) = new DeleteRequest[Ajax.type, Future, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+      cm.client
+        .delete(
+          url     = deriveUriString(cm, uri) + renderQueries(queries),
+          headers = headers
+        )
+        .flatMap(response => decoder(response.responseText))
+    }
+  }
+}


### PR DESCRIPTION
Right now we compile the http4s client to ScalaJS, but as of now, http4s isn't supporting that. It is planned for the next release 0.19 though.

To overcome this problem, I implemented a basic http client using scalajs-doms Ajax class.