### PR TITLE
Add body encodings to the api description

### DIFF
--- a/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
+++ b/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
@@ -68,7 +68,7 @@ package object akkahttp {
                                                                           mat: Materializer) = new PutWithBodyRequest[HttpExt, Future, Bd, A] {
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
-        val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.PUT, entity = marshalledBody)
+        val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.PUT, entity = marshalledBody)
 
         execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
           Unmarshal(response.entity).to[A]
@@ -106,7 +106,7 @@ package object akkahttp {
                                                                            mat: Materializer) = new PostWithBodyRequest[HttpExt, Future, Bd, A] {
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
-        val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.POST, entity = marshalledBody)
+        val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.POST, entity = marshalledBody)
 
         execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
           Unmarshal(response.entity).to[A]

--- a/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
+++ b/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
@@ -1,11 +1,13 @@
 package typedapi.client
 
-import typedapi.shared.MethodType
+import typedapi.shared.{MethodType, MediaType}
 import shapeless._
+import shapeless.labelled.FieldType
 
 import scala.language.higherKinds
 
-final class ExecutableDerivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, O, D <: HList](builder: RequestDataBuilder.Aux[El, KIn, VIn, M, O, D], input: VIn) {
+final class ExecutableDerivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, MT <: MediaType, O, D <: HList]
+  (builder: RequestDataBuilder.Aux[El, KIn, VIn, M, FieldType[MT, O], D], input: VIn) {
 
   final class Derivation[F[_]] {
 

--- a/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
+++ b/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
@@ -52,24 +52,26 @@ trait RequestDataBuilderLowPrio {
       }
     }
 
-  implicit def queryInputCompiler[T <: HList, K <: Symbol, V, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit wit: Witness.Aux[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
+  implicit def queryInputCompiler[T <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
     new RequestDataBuilder[QueryInput :: T, K :: KIn, V :: VIn, M, O] {
       type Out = compiler.Out
 
       def apply(inputs: V :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val queryName  = wit.value.name
+        val queryName  = show.show(wit.value)
         val queryValue = inputs.head
 
         compiler(inputs.tail, uri, Map((queryName, List(queryValue.toString()))) ++ queries, headers)
       }
     }
 
-  implicit def headerInputCompiler[T <: HList, K <: Symbol, V, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit wit: Witness.Aux[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
+  implicit def headerInputCompiler[T <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
     new RequestDataBuilder[HeaderInput :: T, K :: KIn, V :: VIn, M, O] {
       type Out = compiler.Out
 
       def apply(inputs: V :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val headerName  = wit.value.name
+        val headerName  = show.show(wit.value)
         val headerValue = inputs.head
 
         compiler(inputs.tail, uri, queries, Map((headerName, headerValue.toString())) ++ headers)
@@ -161,12 +163,13 @@ trait RequestDataBuilderLowPrio {
 
 trait RequestDataBuilderMediumPrio extends RequestDataBuilderLowPrio {
 
-  implicit def queryOptInputCompiler[T <: HList, K <: Symbol, V, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit wit: Witness.Aux[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
+  implicit def queryOptInputCompiler[T <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
     new RequestDataBuilder[QueryInput :: T, K :: KIn, Option[V] :: VIn, M, O] {
       type Out = compiler.Out
 
       def apply(inputs: Option[V] :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val queryName      = wit.value.name
+        val queryName      = show.show(wit.value)
         val queryValue     = inputs.head
         val updatedQueries = queryValue.fold(queries)(q => Map(queryName -> List(q.toString())) ++ queries)
 
@@ -174,12 +177,13 @@ trait RequestDataBuilderMediumPrio extends RequestDataBuilderLowPrio {
       }
     }
 
-  implicit def queryListInputCompiler[T <: HList, K <: Symbol, V, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit wit: Witness.Aux[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
+  implicit def queryListInputCompiler[T <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
     new RequestDataBuilder[QueryInput :: T, K :: KIn, List[V] :: VIn, M, O] {
       type Out = compiler.Out
 
       def apply(inputs: List[V] :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val queryName  = wit.value.name
+        val queryName  = show.show(wit.value)
         val queryValue = inputs.head
 
         if (queryValue.isEmpty)
@@ -189,12 +193,13 @@ trait RequestDataBuilderMediumPrio extends RequestDataBuilderLowPrio {
       }
     }
 
-  implicit def headersOptInputCompiler[T <: HList, K <: Symbol, V, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit wit: Witness.Aux[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
+  implicit def headersOptInputCompiler[T <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
     new RequestDataBuilder[HeaderInput :: T, K :: KIn, Option[V] :: VIn, M, O] {
       type Out = compiler.Out
 
       def apply(inputs: Option[V] :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val headerName     = wit.value.name
+        val headerName     = show.show(wit.value)
         val headerValue    = inputs.head
         val updatedHeaders = headerValue.fold(headers)(h => Map(headerName -> h.toString()) ++ headers)
 

--- a/client/src/main/scala/typedapi/client/package.scala
+++ b/client/src/main/scala/typedapi/client/package.scala
@@ -7,7 +7,8 @@ import shapeless.ops.hlist.Tupler
 import shapeless.ops.function.FnFromProduct
 
 package object client extends TypeLevelFoldLeftLowPrio 
-                      with TypeLevelFoldLeftListLowPrio 
+                      with TypeLevelFoldLeftListLowPrio
+                      with WitnessToStringLowPrio
                       with ApiTransformer {
 
   def deriveUriString(cm: ClientManager[_], uri: List[String]): String = cm.base + "/" + uri.mkString("/")

--- a/client/src/main/scala/typedapi/client/package.scala
+++ b/client/src/main/scala/typedapi/client/package.scala
@@ -2,6 +2,7 @@ package typedapi
 
 import typedapi.shared._
 import shapeless._
+import shapeless.labelled.FieldType
 import shapeless.ops.hlist.Tupler
 import shapeless.ops.function.FnFromProduct
 
@@ -11,11 +12,12 @@ package object client extends TypeLevelFoldLeftLowPrio
 
   def deriveUriString(cm: ClientManager[_], uri: List[String]): String = cm.base + "/" + uri.mkString("/")
 
-  def derive[H <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out, D <: HList](apiList: ApiTypeCarrier[H])
-                                                                                                   (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, Out)]],
-                                                                                                             builder: RequestDataBuilder.Aux[El, KIn, VIn, M, Out, D],
-                                                                                                             inToFn: FnFromProduct[VIn => ExecutableDerivation[El, KIn, VIn, M, Out, D]]): inToFn.Out = 
-    inToFn.apply(input => new ExecutableDerivation[El, KIn, VIn, M, Out, D](builder, input))
+  def derive[H <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, MT <: MediaType, Out, D <: HList]
+    (apiList: ApiTypeCarrier[H])
+    (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
+              builder: RequestDataBuilder.Aux[El, KIn, VIn, M, FieldType[MT, Out], D],
+              inToFn: FnFromProduct[VIn => ExecutableDerivation[El, KIn, VIn, M, MT, Out, D]]): inToFn.Out =
+    inToFn.apply(input => new ExecutableDerivation[El, KIn, VIn, M, MT, Out, D](builder, input))
 
   def deriveAll[H <: HList, In <: HList, Fold <: HList, B <: HList, Ex <: HList](apiLists: CompositionCons[H])
                                                                                 (implicit folders: TypeLevelFoldLeftList.Aux[H, Fold],

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -24,73 +24,73 @@ final class RequestDataBuilderSpec extends Specification {
 
     "single api" >> {
       "method" >> {
-        val api0 = derive(:= :> Get[ReqInput])
-        api0().run[Id](cm) === ReqInput("GET", Nil, Map(), Map())
-        val api1 = derive(:= :> Put[ReqInput])
-        api1().run[Id](cm) === ReqInput("PUT", Nil, Map(), Map())
-        val api2 = derive(:= :> Post[ReqInput])
-        api2().run[Id](cm) === ReqInput("POST", Nil, Map(), Map())
-        val api3 = derive(:= :> Delete[ReqInput])
-        api3().run[Id](cm) === ReqInput("DELETE", Nil, Map(), Map())
+        val api0 = derive(:= :> Get[Json, ReqInput])
+        api0().run[Id](cm) === ReqInput("GET", Nil, Map(), Map(("Accept", "application/json")))
+        val api1 = derive(:= :> Put[Json, ReqInput])
+        api1().run[Id](cm) === ReqInput("PUT", Nil, Map(), Map(("Accept", "application/json")))
+        val api2 = derive(:= :> Post[Json, ReqInput])
+        api2().run[Id](cm) === ReqInput("POST", Nil, Map(), Map(("Accept", "application/json")))
+        val api3 = derive(:= :> Delete[Json, ReqInput])
+        api3().run[Id](cm) === ReqInput("DELETE", Nil, Map(), Map(("Accept", "application/json")))
       }
       
       "segment" >> {
-        val api0 = derive(:= :> Segment[Int]('i0) :> Get[ReqInput])
-        api0(0).run[Id](cm) === ReqInput("GET", "0" :: Nil, Map(), Map())
-        val api1 = derive(:= :> Segment[Int]('i0) :> Segment[Int]('i1) :> Get[ReqInput])
-        api1(0, 1).run[Id](cm) === ReqInput("GET", "0" :: "1" :: Nil, Map(), Map())
+        val api0 = derive(:= :> Segment[Int]('i0) :> Get[Json, ReqInput])
+        api0(0).run[Id](cm) === ReqInput("GET", "0" :: Nil, Map(), Map(("Accept", "application/json")))
+        val api1 = derive(:= :> Segment[Int]('i0) :> Segment[Int]('i1) :> Get[Json, ReqInput])
+        api1(0, 1).run[Id](cm) === ReqInput("GET", "0" :: "1" :: Nil, Map(), Map(("Accept", "application/json")))
       }
 
       "query" >> {
-        val api0 = derive(:= :> Query[Int]('i0) :> Get[ReqInput])
-        api0(0).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0")), Map())
-        val api1 = derive(:= :> Query[Int]('i0) :> Query[Int]('i1) :> Get[ReqInput])
-        api1(0, 1).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0"), "i1" -> List("1")), Map())
-        val api2 = derive(:= :> Query[List[Int]]('i0) :> Get[ReqInput])
-        api2(List(0, 1)).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0", "1")), Map())
-        api2(Nil).run[Id](cm) === ReqInput("GET", Nil, Map.empty, Map())
-        val api3 = derive(:= :> Query[Option[Int]]('i0) :> Get[ReqInput])
-        api3(Some(0)).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0")), Map())
-        api3(None).run[Id](cm) === ReqInput("GET", Nil, Map.empty, Map())
+        val api0 = derive(:= :> Query[Int]('i0) :> Get[Json, ReqInput])
+        api0(0).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0")), Map(("Accept", "application/json")))
+        val api1 = derive(:= :> Query[Int]('i0) :> Query[Int]('i1) :> Get[Json, ReqInput])
+        api1(0, 1).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0"), "i1" -> List("1")), Map(("Accept", "application/json")))
+        val api2 = derive(:= :> Query[List[Int]]('i0) :> Get[Json, ReqInput])
+        api2(List(0, 1)).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0", "1")), Map(("Accept", "application/json")))
+        api2(Nil).run[Id](cm) === ReqInput("GET", Nil, Map.empty, Map(("Accept", "application/json")))
+        val api3 = derive(:= :> Query[Option[Int]]('i0) :> Get[Json, ReqInput])
+        api3(Some(0)).run[Id](cm) === ReqInput("GET", Nil, Map("i0" -> List("0")), Map(("Accept", "application/json")))
+        api3(None).run[Id](cm) === ReqInput("GET", Nil, Map.empty, Map(("Accept", "application/json")))
       }
 
       "header" >> {
-        val api0 = derive(:= :> Header[Int]('i0) :> Get[ReqInput])
-        api0(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("i0" -> "0"))
-        val api1 = derive(:= :> Header[Int]('i0) :> Header[Int]('i1) :> Get[ReqInput])
-        api1(0, 1).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("i0" -> "0", "i1" -> "1"))
-        val api2 = derive(:= :> Header[Option[Int]]('i0) :> Get[ReqInput])
-        api2(Some(0)).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("i0" -> "0"))
-        api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map.empty)
+        val api0 = derive(:= :> Header[Int]('i0) :> Get[Json, ReqInput])
+        api0(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
+        val api1 = derive(:= :> Header[Int]('i0) :> Header[Int]('i1) :> Get[Json, ReqInput])
+        api1(0, 1).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0", "i1" -> "1"))
+        val api2 = derive(:= :> Header[Option[Int]]('i0) :> Get[Json, ReqInput])
+        api2(Some(0)).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
+        api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
       }
 
       "raw header" >> {
-        val api0 = derive(:= :> RawHeaders :> Get[ReqInput])
-        api0(Map("i0" -> "0")).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("i0" -> "0"))
+        val api0 = derive(:= :> RawHeaders :> Get[Json, ReqInput])
+        api0(Map("i0" -> "0")).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
       }
 
       "request body" >> {
-        val api0 = derive(:= :> ReqBody[Int] :> Put[ReqInputWithBody[Int]])
-        api0(0).run[Id](cm) === ReqInputWithBody("PUT", Nil, Map(), Map(), 0)
+        val api0 = derive(:= :> ReqBody[Json, Int] :> Put[Json, ReqInputWithBody[Int]])
+        api0(0).run[Id](cm)(putB) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json"), ("Content-Type", "application/json")), 0)
       }
 
       "path" >> {
-        val api0 = derive(:= :> "hello" :> "world" :> Get[ReqInput])
-        api0().run[Id](cm) === ReqInput("GET", "hello" :: "world" :: Nil, Map(), Map())
+        val api0 = derive(:= :> "hello" :> "world" :> Get[Json, ReqInput])
+        api0().run[Id](cm) === ReqInput("GET", "hello" :: "world" :: Nil, Map(), Map(("Accept", "application/json")))
       }
     }
 
     "composition" >> {
       val api = 
-        (:= :> "find" :> Get[ReqInput]) :|:
-        (:= :> "fetch" :> Segment[String]('type) :> Get[ReqInput]) :|:
-        (:= :> "store" :> ReqBody[Int] :> Post[ReqInputWithBody[Int]])
+        (:= :> "find" :> Get[Json, ReqInput]) :|:
+        (:= :> "fetch" :> Segment[String]('type) :> Get[Json, ReqInput]) :|:
+        (:= :> "store" :> ReqBody[Json, Int] :> Post[Json, ReqInputWithBody[Int]])
 
       val (find, fetch, store) = deriveAll(api)
 
-      find().run[Id](cm) === ReqInput("GET", "find" :: Nil, Map(), Map())
-      fetch("all").run[Id](cm) === ReqInput("GET", "fetch" :: "all" :: Nil, Map(), Map())
-      store(0).run[Id](cm) === ReqInputWithBody("POST", "store" :: Nil, Map(), Map(), 0)
+      find().run[Id](cm) === ReqInput("GET", "find" :: Nil, Map(), Map(("Accept", "application/json")))
+      fetch("all").run[Id](cm) === ReqInput("GET", "fetch" :: "all" :: Nil, Map(), Map(("Accept", "application/json")))
+      store(0).run[Id](cm) === ReqInputWithBody("POST", "store" :: Nil, Map(), Map(("Accept", "application/json"), ("Content-Type", "application/json")), 0)
     }
   }
 }

--- a/docs/example/client-js/src/main/scala/Client.scala
+++ b/docs/example/client-js/src/main/scala/Client.scala
@@ -29,8 +29,8 @@ object Client {
     val cm = ClientManager(Ajax, "http://localhost", 9000)
 
     (for {
-      u0 <- create("*", User("joe", 27)).run[Future](cm)
-      u1 <- fetch("joe", "*").run[Future](cm)
+      u0 <- create(User("joe", 27)).run[Future](cm)
+      u1 <- fetch("joe").run[Future](cm)
     } yield (u0, u1)).foreach { case (u0, u1) =>
       println(u0)
       println(u1)

--- a/docs/example/client-js/src/main/scala/Client.scala
+++ b/docs/example/client-js/src/main/scala/Client.scala
@@ -18,8 +18,8 @@ object Client {
   final case class DecodeException(msg: String) extends Exception
 
   implicit val decoder = typedapi.client.js.Decoder[Future, User](json => decode[User](json).fold(
-    error => Future.success(Left(DecodeException(error.toString()))), 
-    Right(_)
+    error => Future.successful(Left(DecodeException(error.toString()))), 
+    user  => Future.successful(Right(user))
   ))
   implicit val encoder = typedapi.client.js.Encoder[Future, User](user => Future.successful(user.asJson.noSpaces))
 
@@ -29,8 +29,8 @@ object Client {
     val cm = ClientManager(Ajax, "http://localhost", 9000)
 
     (for {
-      u0 <- create(User("joe", 27)).run[Future](cm)
-      u1 <- fetch("joe").run[Future](cm)
+      u0 <- create("*", User("joe", 27)).run[Future](cm)
+      u1 <- fetch("joe", "*").run[Future](cm)
     } yield (u0, u1)).foreach { case (u0, u1) =>
       println(u0)
       println(u1)

--- a/docs/example/client-jvm/src/main/scala/Client.scala
+++ b/docs/example/client-jvm/src/main/scala/Client.scala
@@ -20,8 +20,8 @@ object Client {
     val cm = ClientManager(Http1Client[IO]().unsafeRunSync, "http://localhost", 9000)
 
     (for {
-      u0 <- create("*", User("joe", 27)).run[IO](cm)
-      u1 <- fetch("joe", "*").run[IO](cm)
+      u0 <- create(User("joe", 27)).run[IO](cm)
+      u1 <- fetch("joe").run[IO](cm)
     } yield {
       println(u0)
       println(u1)

--- a/docs/example/client-jvm/src/main/scala/Client.scala
+++ b/docs/example/client-jvm/src/main/scala/Client.scala
@@ -20,8 +20,8 @@ object Client {
     val cm = ClientManager(Http1Client[IO]().unsafeRunSync, "http://localhost", 9000)
 
     (for {
-      u0 <- create(User("joe", 27)).run[IO](cm)
-      u1 <- fetch("joe").run[IO](cm)
+      u0 <- create("*", User("joe", 27)).run[IO](cm)
+      u1 <- fetch("joe", "*").run[IO](cm)
     } yield {
       println(u0)
       println(u1)

--- a/docs/example/server/src/main/scala/Server.scala
+++ b/docs/example/server/src/main/scala/Server.scala
@@ -10,8 +10,8 @@ object Server {
   implicit val decoder = jsonOf[IO, User]
   implicit val encoder = jsonEncoderOf[IO, User]
 
-  val fetch: (String, String) => IO[User] = (name, _) => IO.pure(User(name, 27))
-  val create: (String, User) => IO[User] = (_, user) => IO.pure(user)
+  val fetch: String => IO[User] = name => IO.pure(User(name, 27))
+  val create: User  => IO[User] = user => IO.pure(user)
 
   val endpoints = deriveAll[IO](FromDefinition.MyApi).from(fetch, create)
 

--- a/docs/example/server/src/main/scala/Server.scala
+++ b/docs/example/server/src/main/scala/Server.scala
@@ -10,8 +10,8 @@ object Server {
   implicit val decoder = jsonOf[IO, User]
   implicit val encoder = jsonEncoderOf[IO, User]
 
-  val fetch: String => IO[User] = name => IO.pure(User(name, 27))
-  val create: User => IO[User] = user => IO.pure(user)
+  val fetch: (String, String) => IO[User] = (name, _) => IO.pure(User(name, 27))
+  val create: (String, User) => IO[User] = (_, user) => IO.pure(user)
 
   val endpoints = deriveAll[IO](FromDefinition.MyApi).from(fetch, create)
 

--- a/docs/example/shared/src/main/scala/Apis.scala
+++ b/docs/example/shared/src/main/scala/Apis.scala
@@ -5,9 +5,9 @@ object FromDsl {
 
   val MyApi = 
     // GET /fetch/user?name=<>
-    (:= :> "fetch" :> "user" :> Query[String]('name) :> Get[User]) :|:
+    (:= :> "fetch" :> "user" :> Query[String]('name) :> Header[String]("Access-Control-Allow-Origin") :> Get[Json, User]) :|:
     // POST /create/user
-    (:= :> "create" :> "user" :> ReqBody[User] :> Post[User])
+    (:= :> "create" :> "user" :> Header[String]("Access-Control-Allow-Origin") :> ReqBody[Json, User] :> Post[Json, User])
 }
 
 object FromDefinition {
@@ -16,7 +16,17 @@ object FromDefinition {
 
   val MyApi =
     // GET /fetch/user?name=<>
-    api(method = Get[User], path = Root / "fetch" / "user", queries = Queries add Query[String]('name)) :|:
+    api(
+      method = Get[Json, User], 
+      path = Root / "fetch" / "user", 
+      queries = Queries add Query[String]('name),
+      headers = Headers add Header[String]("Access-Control-Allow-Origin")
+    ) :|:
     // POST /create/user
-    apiWithBody(method = Post[User], body = ReqBody[User], path = Root / "create" / "user")
+    apiWithBody(
+      method = Post[Json, User], 
+      body = ReqBody[Json, User], 
+      path = Root / "create" / "user",
+      headers = Headers add Header[String]("Access-Control-Allow-Origin")
+    )
 }

--- a/docs/example/shared/src/main/scala/Apis.scala
+++ b/docs/example/shared/src/main/scala/Apis.scala
@@ -5,9 +5,9 @@ object FromDsl {
 
   val MyApi = 
     // GET /fetch/user?name=<>
-    (:= :> "fetch" :> "user" :> Query[String]('name) :> Header[String]("Access-Control-Allow-Origin") :> Get[Json, User]) :|:
+    (:= :> "fetch" :> "user" :> Query[String]('name) :> Get[Json, User]) :|:
     // POST /create/user
-    (:= :> "create" :> "user" :> Header[String]("Access-Control-Allow-Origin") :> ReqBody[Json, User] :> Post[Json, User])
+    (:= :> "create" :> "user" :> ReqBody[Json, User] :> Post[Json, User])
 }
 
 object FromDefinition {
@@ -19,14 +19,12 @@ object FromDefinition {
     api(
       method = Get[Json, User], 
       path = Root / "fetch" / "user", 
-      queries = Queries add Query[String]('name),
-      headers = Headers add Header[String]("Access-Control-Allow-Origin")
+      queries = Queries add Query[String]('name)
     ) :|:
     // POST /create/user
     apiWithBody(
       method = Post[Json, User], 
       body = ReqBody[Json, User], 
-      path = Root / "create" / "user",
-      headers = Headers add Header[String]("Access-Control-Allow-Origin")
+      path = Root / "create" / "user"
     )
 }

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -34,25 +34,25 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
-      s("jim").run[Future](cm) must beEqualTo( User("jim", 27)).awaitFor(timeout)
+      s("jim").run[Future](cm) must beEqualTo(User("jim", 27)).awaitFor(timeout)
     }
     
     "queries" >> {
-      q(42).run[Future](cm) must beEqualTo( User("foo", 42)).awaitFor(timeout)
+      q(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
     }
     
     "headers" >> {
-      h0(42).run[Future](cm) must beEqualTo( User("foo", 42)).awaitFor(timeout)
-      h1(42, Map("name" -> "jim")).run[Future](cm) must beEqualTo( User("jim", 42)).awaitFor(timeout)
+      h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
+      h1(42, Map("name" -> "jim")).run[Future](cm) must beEqualTo(User("jim", 42)).awaitFor(timeout)
     }
 
     "methods" >> {
-      m0().run[Future](cm) must beEqualTo( User("foo", 27)).awaitFor(timeout)
-      m1().run[Future](cm) must beEqualTo( User("foo", 27)).awaitFor(timeout)
-      m2(User("jim", 42)).run[Future](cm) must beEqualTo( User("jim", 42)).awaitFor(timeout)
-      m3().run[Future](cm) must beEqualTo( User("foo", 27)).awaitFor(timeout)
-      m4(User("jim", 42)).run[Future](cm) must beEqualTo( User("jim", 42)).awaitFor(timeout)
-      m5(List("because")).run[Future](cm) must beEqualTo( User("foo", 27)).awaitFor(timeout)
+      m0().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
+      m1().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
+      m2(User("jim", 42)).run[Future](cm) must beEqualTo(User("jim", 42)).awaitFor(timeout)
+      m3().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
+      m4(User("jim", 42)).run[Future](cm) must beEqualTo(User("jim", 42)).awaitFor(timeout)
+      m5(List("because")).run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
     }
 
     step {

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -5,15 +5,15 @@ import typedapi.dsl._
 package object tests {
 
   val Api =
-    (:= :> "path" :> Get[User]) :|:
-    (:= :> "segment" :> Segment[String]('name) :> Get[User]) :|:
-    (:= :> "query" :> Query[Int]('age) :> Get[User]) :|:
-    (:= :> "header" :> Header[Int]('age) :> Get[User]) :|:
-    (:= :> "header" :> "raw" :> Header[Int]('age) :> RawHeaders :> Get[User]) :|:
-    (:= :> Get[User]) :|:
-    (:= :> Put[User]) :|:
-    (:= :> "body" :> ReqBody[User] :> Put[User]) :|:
-    (:= :> Post[User]) :|:
-    (:= :> "body" :> ReqBody[User] :> Post[User]) :|:
-    (:= :> Query[List[String]]('reasons) :> Delete[User])
+    (:= :> "path" :> Get[Json, User]) :|:
+    (:= :> "segment" :> Segment[String]('name) :> Get[Json, User]) :|:
+    (:= :> "query" :> Query[Int]('age) :> Get[Json, User]) :|:
+    (:= :> "header" :> Header[Int]('age) :> Get[Json, User]) :|:
+    (:= :> "header" :> "raw" :> Header[Int]('age) :> RawHeaders :> Get[Json, User]) :|:
+    (:= :> Get[Json, User]) :|:
+    (:= :> Put[Json, User]) :|:
+    (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:
+    (:= :> Post[Json, User]) :|:
+    (:= :> "body" :> ReqBody[Json, User] :> Post[Json, User]) :|:
+    (:= :> Query[List[String]]('reasons) :> Delete[Json, User])
 }

--- a/js-client/src/main/scala/typedapi/client/js/package.scala
+++ b/js-client/src/main/scala/typedapi/client/js/package.scala
@@ -7,9 +7,12 @@ import scala.concurrent.{Future, ExecutionContext}
 package object js {
 
   private def renderQueries(queries: Map[String, List[String]]): String = 
-    queries
-      .map { case (key, values) => s"$key=${values.mkString(",")}" }
-      .mkString("?", "&", "")
+    if (queries.nonEmpty)
+      queries
+        .map { case (key, values) => s"$key=${values.mkString(",")}" }
+        .mkString("?", "&", "")
+  else
+    ""
 
   private def flatten[A](decoded: Future[Either[Exception, A]])(implicit ec: ExecutionContext): Future[A] = decoded.flatMap {
     case Right(a)    => Future.successful(a)

--- a/server/src/main/scala/typedapi/server/Endpoint.scala
+++ b/server/src/main/scala/typedapi/server/Endpoint.scala
@@ -2,6 +2,7 @@ package typedapi.server
 
 import typedapi.shared._
 import shapeless._
+import shapeless.labelled.FieldType
 import shapeless.ops.function._
 
 import scala.language.higherKinds
@@ -20,8 +21,9 @@ final case class EndpointRequest(method: String,
 
 final class ExecutableDerivation[F[_]] {
 
-  final class Derivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, Fn, Out](extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut], 
-                                                                                                  fnToVIn: FnToProduct.Aux[Fn, VIn => F[Out]]) {
+  final class Derivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, Fn, Out]
+    (extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+     fnToVIn: FnToProduct.Aux[Fn, VIn => F[Out]]) {
 
     /** Restricts type of parameter `fn` to a function defined by the given API:
       * 
@@ -39,10 +41,11 @@ final class ExecutableDerivation[F[_]] {
       }
   }
 
-  def apply[H <: HList, El <: HList, KIn <: HList, VIn <: HList, ROut, Fn, M <: MethodType, Out](apiList: ApiTypeCarrier[H])
-                                                                                                (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, Out)]],
-                                                                                                          extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
-                                                                                                          inToFn: Lazy[FnFromProduct.Aux[VIn => F[Out], Fn]],
-                                                                                                          fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]]): Derivation[El, KIn, VIn, M, ROut, Fn, Out] =
+  def apply[H <: HList, El <: HList, KIn <: HList, VIn <: HList, ROut, Fn, M <: MethodType, MT <: MediaType, Out]
+    (apiList: ApiTypeCarrier[H])
+    (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
+              extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+              inToFn: Lazy[FnFromProduct.Aux[VIn => F[Out], Fn]],
+              fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]]): Derivation[El, KIn, VIn, M, ROut, Fn, Out] =
     new Derivation[El, KIn, VIn, M, ROut, Fn, Out](extractor, fnToVIn.value)
 }

--- a/server/src/main/scala/typedapi/server/EndpointComposition.scala
+++ b/server/src/main/scala/typedapi/server/EndpointComposition.scala
@@ -2,6 +2,7 @@ package typedapi.server
 
 import typedapi.shared._
 import shapeless._
+import shapeless.labelled.FieldType
 import shapeless.ops.function._
 
 import scala.language.higherKinds
@@ -45,12 +46,12 @@ trait PrecompileEndpointLowPrio {
     val constructors = HNil
   }
 
-  implicit def constructorsCase[F[_], Fn, El <: HList, KIn <: HList, VIn <: HList, Out, M <: MethodType, ROut, T <: HList]
+  implicit def constructorsCase[F[_], Fn, El <: HList, KIn <: HList, VIn <: HList, MT <: MediaType, Out, M <: MethodType, ROut, T <: HList]
     (implicit extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
               vinToFn: FnFromProduct.Aux[VIn => F[Out], Fn],
               fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]],
               next: PrecompileEndpoint[F, T]) =
-    new PrecompileEndpoint[F, (El, KIn, VIn, M, Out) :: T] {
+    new PrecompileEndpoint[F, (El, KIn, VIn, M, FieldType[MT, Out]) :: T] {
       type Fns    = Fn :: next.Fns
       type Consts = EndpointConstructor[F, Fn, El, KIn, VIn, M, ROut, Out] :: next.Consts
 

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -2,6 +2,7 @@ package typedapi.server
 
 import typedapi.shared._
 import shapeless.{HList, HNil, Witness}
+import shapeless.labelled.FieldType
 import shapeless.ops.hlist.Reverse
 
 import scala.util.Try
@@ -182,16 +183,17 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     }
   }
 
-  implicit def putWithBodyExtractor[Bd, EIn <: HList] = new RouteExtractor[HNil, shapeless.::[BodyField.T, HNil], shapeless.::[Bd, HNil], PutWithBodyCall, EIn] {
-    type Out = (BodyType[Bd], EIn)
+  implicit def putWithBodyExtractor[BMT <: MediaType, Bd, EIn <: HList] = 
+    new RouteExtractor[HNil, shapeless.::[FieldType[BMT, BodyField.T], HNil], shapeless.::[Bd, HNil], PutWithBodyCall, EIn] {
+      type Out = (BodyType[Bd], EIn)
 
-    def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "PUT") 
-        Right((BodyType[Bd], inAgg))
-      else 
-        NotFoundE
+      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
+        if (req.method == "PUT")
+          Right((BodyType[Bd], inAgg))
+        else
+          NotFoundE
+      }
     }
-  }
 
   implicit def postExtractor[EIn <: HList] = new RouteExtractor[HNil, HNil, HNil, PostCall, EIn] {
     type Out = EIn
@@ -204,16 +206,17 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     }
   }
 
-  implicit def postWithBodyExtractor[Bd, EIn <: HList, REIn <: HList] = new RouteExtractor[HNil, shapeless.::[BodyField.T, HNil], shapeless.::[Bd, HNil], PostWithBodyCall, EIn] {
-    type Out = (BodyType[Bd], EIn)
+  implicit def postWithBodyExtractor[BMT <: MediaType, Bd, EIn <: HList, REIn <: HList] = 
+    new RouteExtractor[HNil, shapeless.::[FieldType[BMT, BodyField.T], HNil], shapeless.::[Bd, HNil], PostWithBodyCall, EIn] {
+      type Out = (BodyType[Bd], EIn)
 
-    def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "POST") 
-        Right((BodyType[Bd], inAgg))
-      else 
-        NotFoundE
+      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
+        if (req.method == "POST")
+          Right((BodyType[Bd], inAgg))
+        else
+          NotFoundE
+      }
     }
-  }
 
   implicit def deleteExtractor[EIn <: HList] = new RouteExtractor[HNil, HNil, HNil, DeleteCall, EIn] {
     type Out = EIn
@@ -227,7 +230,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
   }
 }
 
-sealed trait ValueExtractor[A] extends (String => Option[A]) {
+trait ValueExtractor[A] extends (String => Option[A]) {
 
   def typeDesc: String
 }

--- a/server/src/main/scala/typedapi/server/package.scala
+++ b/server/src/main/scala/typedapi/server/package.scala
@@ -13,8 +13,9 @@ package object server extends TypeLevelFoldLeftLowPrio
   def derive[F[_]]: ExecutableDerivation[F] = new ExecutableDerivation[F]
 
 
-  def mount[S, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut, Req, Resp, Out](server: ServerManager[S], endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut])
-                                                                                                          (implicit executor: EndpointExecutor.Aux[Req, El, KIn, VIn, M, ROut, F, FOut, Resp], mounting: MountEndpoints.Aux[S, Req, Resp, Out]): Out =
+  def mount[S, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut, Req, Resp, Out]
+      (server: ServerManager[S], endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut])
+      (implicit executor: EndpointExecutor.Aux[Req, El, KIn, VIn, M, ROut, F, FOut, Resp], mounting: MountEndpoints.Aux[S, Req, Resp, Out]): Out =
     mounting(server, List(new Serve[executor.R, executor.Out] {
       def apply(req: executor.R, eReq: EndpointRequest): Either[ExtractionError, executor.Out] = executor(req, eReq, endpoint)
     }))

--- a/server/src/main/scala/typedapi/server/package.scala
+++ b/server/src/main/scala/typedapi/server/package.scala
@@ -8,6 +8,7 @@ import scala.language.higherKinds
 
 package object server extends TypeLevelFoldLeftLowPrio 
                       with TypeLevelFoldLeftListLowPrio 
+                      with WitnessToStringLowPrio
                       with ApiTransformer {
 
   def derive[F[_]]: ExecutableDerivation[F] = new ExecutableDerivation[F]

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -10,7 +10,7 @@ final class ApiToEndpointLinkSpec extends Specification {
   case class Foo(name: String)
 
   "link api definitions to endpoint functions" >> { 
-    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Get[List[Foo]]
+    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Get[Json, List[Foo]]
 
     val endpoint0 = derive[Option].apply(Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
     endpoint0("john" :: 10 :: HNil) === Some(List(Foo("john")))

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -16,7 +16,7 @@ final class RouteExtractorSpec extends Specification {
 
   "determine routes defined by requests and extract included data (segments, queries, headers)" >> {
     "no data" >> {
-      val ext = extract(:= :> "hello" :> "world" :> Get[Foo])
+      val ext = extract(:= :> "hello" :> "world" :> Get[Json, Foo])
       
       ext(EndpointRequest("GET", List("hello", "world"), Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
       ext(EndpointRequest("GET", List("hello", "wrong"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
@@ -25,7 +25,7 @@ final class RouteExtractorSpec extends Specification {
     }
 
     "segments" >> {
-      val ext = extract(:= :> "foo" :> Segment[Int]('age) :> Get[Foo])
+      val ext = extract(:= :> "foo" :> Segment[Int]('age) :> Get[Json, Foo])
 
       ext(EndpointRequest("GET", List("foo", "0"), Map.empty, Map.empty), Set.empty, HNil) === Right(0 :: HNil)
       ext(EndpointRequest("GET", List("foo", "wrong"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
@@ -34,7 +34,7 @@ final class RouteExtractorSpec extends Specification {
     }
 
     "queries" >> {
-      val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Get[Foo])
+      val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Get[Json, Foo])
 
       ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), Set.empty, HNil) === Right(0 :: HNil)
       ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("wrong")), Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("query 'age' has not type Int")
@@ -42,19 +42,19 @@ final class RouteExtractorSpec extends Specification {
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing query 'age'")
       ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
-      val ext1 = extract(:= :> "foo" :> Query[Option[Int]]('age) :> Get[Foo])
+      val ext1 = extract(:= :> "foo" :> Query[Option[Int]]('age) :> Get[Json, Foo])
 
       ext1(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), Set.empty, HNil) === Right(Some(0) :: HNil)
       ext1(EndpointRequest("GET", List("foo"), Map("wrong" -> List("0")), Map.empty), Set.empty, HNil) === Right(None :: HNil)
 
-      val ext2 = extract(:= :> "foo" :> Query[List[Int]]('age) :> Get[Foo])
+      val ext2 = extract(:= :> "foo" :> Query[List[Int]]('age) :> Get[Json, Foo])
 
       ext2(EndpointRequest("GET", List("foo"), Map("age" -> List("0", "1")), Map.empty), Set.empty, HNil) === Right(List(0, 1) :: HNil)
       ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(Nil :: HNil)
     }
 
     "headers" >> {
-      val ext0 = extract(:= :> "foo" :> Header[Int]('age) :> Get[Foo])
+      val ext0 = extract(:= :> "foo" :> Header[Int]('age) :> Get[Json, Foo])
 
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(0 :: HNil)
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'age' has not type Int")
@@ -63,60 +63,60 @@ final class RouteExtractorSpec extends Specification {
       ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
       //raw
-      val ext1 = extract(:= :> "foo" :> RawHeaders :> Get[Foo])
+      val ext1 = extract(:= :> "foo" :> RawHeaders :> Get[Json, Foo])
 
       ext1(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "blah")), Set.empty, HNil) === Right(Map("age" -> "blah") :: HNil)
       ext1(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("no raw headers left, but at least one expected")
 
       // headers and raw
-      val ext2 = extract(:= :> "foo" :> Header[Int]('age) :> RawHeaders :> Get[Foo])
+      val ext2 = extract(:= :> "foo" :> Header[Int]('age) :> RawHeaders :> Get[Json, Foo])
 
       ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === RouteExtractor.BadRequestE("no raw headers left, but at least one expected")
       ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0", "foo" -> "bar")), Set.empty, HNil) === Right(0 :: Map("foo" -> "bar") :: HNil)
 
-      val ext3 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Foo])
+      val ext3 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Json, Foo])
 
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(Some(0) :: HNil)
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(None :: HNil)
     }
 
     "body type" >> {
-      val ext0 = extract(:= :> ReqBody[Foo] :> Put[Foo])
+      val ext0 = extract(:= :> ReqBody[Json, Foo] :> Put[Json, Foo])
 
       ext0(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
       ext0(EndpointRequest("PUT", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
-      val ext1 = extract(:= :> ReqBody[Foo] :> Post[Foo])
+      val ext1 = extract(:= :> ReqBody[Json, Foo] :> Post[Json, Foo])
 
       ext1(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
     }
 
     "methods" >> {
-      val ext0 = extract(:= :> Get[Foo])
+      val ext0 = extract(:= :> Get[Json, Foo])
 
       ext0(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
       ext0(EndpointRequest("WRONG", Nil, Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
-      val ext1 = extract(:= :> Put[Foo])
+      val ext1 = extract(:= :> Put[Json, Foo])
 
       ext1(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
 
-      val ext2 = extract(:= :> Post[Foo])
+      val ext2 = extract(:= :> Post[Json, Foo])
 
       ext2(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
 
-      val ext3 = extract(:= :> Delete[Foo])
+      val ext3 = extract(:= :> Delete[Json, Foo])
 
       ext3(EndpointRequest("DELETE", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
     }
 
     "combinations" >> {
-      val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Header[String]('id) :> Get[Foo])
+      val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Header[String]('id) :> Get[Json, Foo])
 
       ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map("id" -> "john")), Set.empty, HNil) === Right(0 :: "john" :: HNil)
 
-      val ext1 = extract(:= :> Get[Foo])
+      val ext1 = extract(:= :> Get[Json, Foo])
 
       ext1(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
     }

--- a/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
+++ b/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
@@ -54,7 +54,7 @@ final class ServeAndMountSpec extends Specification {
 
   "serve endpoints as simple Request -> Response functions and mount them into a server" >> {
     "serve single endpoint and no body" >> {
-      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Get[List[Foo]]
+      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Get[Json, List[Foo]]
       val endpoint = derive[Option](Api).from((name, sortByAge) => Some(List(Foo(name))))
       val served   = toList(endpoint)
 
@@ -65,7 +65,7 @@ final class ServeAndMountSpec extends Specification {
     }
 
     "serve single endpoint and with body" >> {
-      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> ReqBody[Foo] :> Post[List[Foo]]
+      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> ReqBody[Json, Foo] :> Post[Json, List[Foo]]
       val endpoint = derive[Option](Api).from((name, body) => Some(List(Foo(name), body)))
       val served   = toList(endpoint)
 
@@ -77,8 +77,8 @@ final class ServeAndMountSpec extends Specification {
 
     "serve multiple endpoints" >> {
       val Api = 
-        (:= :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Get[List[Foo]]) :|:
-        (:= :> "create" :> "user" :> ReqBody[Foo] :> Post[Foo])
+        (:= :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Get[Json, List[Foo]]) :|:
+        (:= :> "create" :> "user" :> ReqBody[Json, Foo] :> Post[Json, Foo])
 
       def find(name: String, age: Int): Option[List[Foo]] = Some(List(Foo(name)))
       def create(foo: Foo): Option[Foo] = Some(foo)

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -18,11 +18,11 @@ sealed trait ApiList[H <: HList]
 sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
 
   def :>(headers: RawHeadersParam.type): RawHeadersCons[RawHeadersParam.type :: H] = RawHeadersCons()
-  def :>[A](body: ReqBodyElement[A]): WithBodyCons[A, H] = WithBodyCons()
-  def :>[A](get: GetElement[A]): ApiTypeCarrier[GetElement[A] :: H] = ApiTypeCarrier()
-  def :>[A](put: PutElement[A]): ApiTypeCarrier[PutElement[A] :: H] = ApiTypeCarrier()
-  def :>[A](post: PostElement[A]): ApiTypeCarrier[PostElement[A] :: H] = ApiTypeCarrier()
-  def :>[A](delete: DeleteElement[A]): ApiTypeCarrier[DeleteElement[A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](body: ReqBodyElement[MT, A]): WithBodyCons[MT, A, H] = WithBodyCons()
+  def :>[MT <: MediaType, A](get: GetElement[MT, A]): ApiTypeCarrier[GetElement[MT, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](put: PutElement[MT, A]): ApiTypeCarrier[PutElement[MT, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](post: PostElement[MT, A]): ApiTypeCarrier[PostElement[MT, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](delete: DeleteElement[MT, A]): ApiTypeCarrier[DeleteElement[MT, A] :: H] = ApiTypeCarrier()
 }
 
 /** Initial element with empty api description. */
@@ -70,8 +70,8 @@ final case class RawHeadersCons[H <: HList]() extends ApiListWithOps[H]
 
 
 /** Last set element is a request body. */
-final case class WithBodyCons[Bd, H <: HList]() extends ApiList[H] {
+final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {
 
-  def :>[A](put: PutElement[A]): ApiTypeCarrier[PutWithBodyElement[Bd, A] :: H] = ApiTypeCarrier()
-  def :>[A](post: PostElement[A]): ApiTypeCarrier[PostWithBodyElement[Bd, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](put: PutElement[MT, A]): ApiTypeCarrier[PutWithBodyElement[BMT, Bd, MT, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](post: PostElement[MT, A]): ApiTypeCarrier[PostWithBodyElement[BMT, Bd, MT, A] :: H] = ApiTypeCarrier()
 }

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -29,40 +29,40 @@ sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
 case object EmptyCons extends ApiListWithOps[HNil] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: HNil] = PathCons()
-  def :>[S <: Symbol, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: HNil] = SegmentCons()
-  def :>[S <: Symbol, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: HNil] = QueryCons()  
-  def :>[S <: Symbol, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: HNil] = HeaderCons()
+  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: HNil] = SegmentCons()
+  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: HNil] = QueryCons()  
+  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: HNil] = HeaderCons()
 }
 
 /** Last set element is a path. */
 final case class PathCons[H <: HList]() extends ApiListWithOps[H] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[S <: Symbol, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
-  def :>[S <: Symbol, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()  
-  def :>[S <: Symbol, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
+  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()  
+  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
 }
 
 /** Last set element is a segment. */
 final case class SegmentCons[H <: HList]() extends ApiListWithOps[H] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[S <: Symbol, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
-  def :>[S <: Symbol, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
-  def :>[S <: Symbol, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
+  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
+  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
 }
 
 /** Last set element is a query parameter. */
 final case class QueryCons[H <: HList]() extends ApiListWithOps[H]  {
 
-  def :>[S <: Symbol, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
-  def :>[S <: Symbol, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
+  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
 }
 
 /** Last set element is a header. */
 final case class HeaderCons[H <: HList]() extends ApiListWithOps[H] {
 
-  def :>[S <: Symbol, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
 }
 
 /** Last set element is a header. */

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -19,8 +19,6 @@ package object dsl {
   def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
   def Get[MT <: MediaType, A] = GetElement[MT, A]
   def Put[MT <: MediaType, A] = PutElement[MT, A]
-//  def PutWithBody[BMT <: MediaType, Bd, MT <: MediaType, A] = PutWithBodyElement[BMT, Bd, MT, A]
   def Post[MT <: MediaType, A] = PostElement[MT, A]
-//  def PostWithBody[BMT <: MediaType, Bd, MT <: MediaType, A] = PostWithBodyElement[BMT, Bd, MT, A]
   def Delete[MT <: MediaType, A] = DeleteElement[MT, A]
 }

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -12,11 +12,15 @@ package object dsl {
   def Query[A]   = new QueryHelper[A]
   def Header[A]  = new HeaderHelper[A]
   val RawHeaders = RawHeadersParam
-  def ReqBody[A] = ReqBodyElement[A]
-  def Get[A] = GetElement[A]
-  def Put[A] = PutElement[A]
-  def PutWithBody[Bd, A] = PutWithBodyElement[Bd, A]
-  def Post[A] = PostElement[A]
-  def PostWithBody[Bd, A] = PostWithBodyElement[Bd, A]
-  def Delete[A] = DeleteElement[A]
+
+  type Json  = `Application/Json`.type
+  type Plain = `Text/Plain`.type
+
+  def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
+  def Get[MT <: MediaType, A] = GetElement[MT, A]
+  def Put[MT <: MediaType, A] = PutElement[MT, A]
+//  def PutWithBody[BMT <: MediaType, Bd, MT <: MediaType, A] = PutWithBodyElement[BMT, Bd, MT, A]
+  def Post[MT <: MediaType, A] = PostElement[MT, A]
+//  def PostWithBody[BMT <: MediaType, Bd, MT <: MediaType, A] = PostWithBodyElement[BMT, Bd, MT, A]
+  def Delete[MT <: MediaType, A] = DeleteElement[MT, A]
 }

--- a/shared/src/main/scala/typedapi/package.scala
+++ b/shared/src/main/scala/typedapi/package.scala
@@ -17,17 +17,20 @@ package object typedapi extends MethodToReqBodyLowPrio {
   def Header[A]  = new HeaderHelper[A]
   val RawHeaders = RawHeadersParam
 
-  def ReqBody[A] = ReqBodyElement[A]
-  def Get[A]     = GetElement[A]
-  def Put[A]     = PutElement[A]
-  def Post[A]    = PostElement[A]
-  def Delete[A]  = DeleteElement[A]
+  def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
+  def Get[MT <: MediaType, A]     = GetElement[MT, A]
+  def Put[MT <: MediaType, A]     = PutElement[MT, A]
+  def Post[MT <: MediaType, A]    = PostElement[MT, A]
+  def Delete[MT <: MediaType, A]  = DeleteElement[MT, A]
+
+  type Json  = `Application/Json`.type
+  type Plain = `Text/Plain`.type
 
   def api[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList]
       (method: M, path: PathList[P] = Root, queries: QueryList[Q] = NoQueries, headers: HeaderList[H] = NoHeaders)
       (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api]): ApiTypeCarrier[M :: Api] = ApiTypeCarrier()
 
-  def apiWithBody[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList, Bd]
-      (method: M, body: ReqBodyElement[Bd], path: PathList[P] = Root, queries: QueryList[Q] = NoQueries, headers: HeaderList[H] = NoHeaders)
-      (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api], m: MethodToReqBody[M, Bd]): ApiTypeCarrier[m.Out :: Api] = ApiTypeCarrier()
+  def apiWithBody[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList, BMT <: MediaType, Bd]
+      (method: M, body: ReqBodyElement[BMT, Bd], path: PathList[P] = Root, queries: QueryList[Q] = NoQueries, headers: HeaderList[H] = NoHeaders)
+      (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api], m: MethodToReqBody[M, BMT, Bd]): ApiTypeCarrier[m.Out :: Api] = ApiTypeCarrier()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -16,33 +16,33 @@ final case class PathElement[S](wit: Witness.Lt[S]) extends ApiElement
   * 
   * @param name unique name reference
   */
-final case class SegmentParam[S <: Symbol, A](name: Witness.Lt[S]) extends ApiElement
+final case class SegmentParam[S, A](name: Witness.Lt[S]) extends ApiElement
 
 final class SegmentHelper[A] {
 
-  def apply[S <: Symbol](wit: Witness.Lt[S]) = SegmentParam[S, A](wit)
+  def apply[S](wit: Witness.Lt[S]) = SegmentParam[S, A](wit)
 }
 
 /** Query parameter which represents its key as singleton type and describes the value type.
   * 
   * @param name query key
   */
-final case class QueryParam[S <: Symbol, A](name: Witness.Lt[S]) extends ApiElement
+final case class QueryParam[S, A](name: Witness.Lt[S]) extends ApiElement
 
 final class QueryHelper[A] {
 
-  def apply[S <: Symbol](wit: Witness.Lt[S]) = QueryParam[S, A](wit)
+  def apply[S](wit: Witness.Lt[S]) = QueryParam[S, A](wit)
 }
 
 /** Header which represents its key as singleton type and describes the value type.
   * 
   * @param name header key
   */
-final case class HeaderParam[S <: Symbol, A](name: Witness.Lt[S]) extends ApiElement
+final case class HeaderParam[S, A](name: Witness.Lt[S]) extends ApiElement
 
 final class HeaderHelper[A] {
 
-  def apply[S <: Symbol](wit: Witness.Lt[S]) = HeaderParam[S, A](wit)
+  def apply[S](wit: Witness.Lt[S]) = HeaderParam[S, A](wit)
 }
 
 /** Convenience class to add headers as `Map[String, String]` patch. This class cannot guarantee type safety.

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -52,32 +52,43 @@ final class HeaderHelper[A] {
 case object RawHeadersParam extends ApiElement
 
 /** Request body type description. */
-final case class ReqBodyElement[A]() extends ApiElement
+final case class ReqBodyElement[MT <: MediaType, A]() extends ApiElement
 
-sealed trait MethodElement extends ApiElement
-final case class GetElement[A]() extends MethodElement
-final case class PutElement[A]() extends MethodElement
-final case class PutWithBodyElement[Bd, A]() extends MethodElement
-final case class PostElement[A]() extends MethodElement
-final case class PostWithBodyElement[Bd, A]() extends MethodElement
-final case class DeleteElement[A]() extends MethodElement
+trait MethodElement extends ApiElement
+final case class GetElement[MT <: MediaType, A]() extends MethodElement
+final case class PutElement[MT <: MediaType, A]() extends MethodElement
+final case class PutWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A]() extends MethodElement
+final case class PostElement[MT <: MediaType, A]() extends MethodElement
+final case class PostWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A]() extends MethodElement
+final case class DeleteElement[MT <: MediaType, A]() extends MethodElement
 
 @implicitNotFound("""You try to add a request body to a method which doesn't expect one.
 
 method: ${M}
 """)
-sealed trait MethodToReqBody[M <: MethodElement, Bd] {
+trait MethodToReqBody[M <: MethodElement, MT <: MediaType, Bd] {
 
   type Out <: MethodElement
 }
 
 trait MethodToReqBodyLowPrio {
 
-  implicit def putToReqBody[A, Bd] = new MethodToReqBody[PutElement[A], Bd] {
-    type Out = PutWithBodyElement[Bd, A]
+  implicit def putToReqBody[MT <: MediaType, A, BMT <: MediaType, Bd] = new MethodToReqBody[PutElement[MT, A], BMT, Bd] {
+    type Out = PutWithBodyElement[BMT, Bd, MT, A]
   }
 
-  implicit def postToReqBody[A, Bd] = new MethodToReqBody[PostElement[A], Bd] {
-    type Out = PostWithBodyElement[Bd, A]
+  implicit def postToReqBody[MT <: MediaType, A, BMT <: MediaType, Bd] = new MethodToReqBody[PostElement[MT, A], BMT, Bd] {
+    type Out = PostWithBodyElement[BMT, Bd, MT, A]
   }
+}
+
+trait MediaType {
+
+  def value: String
+}
+case object `Application/Json` extends MediaType {
+  val value = "application/json"
+}
+case object `Text/Plain` extends MediaType {
+  val value = "text/plain"
 }

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -8,8 +8,7 @@ final case class ApiTypeCarrier[H <: HList]() {
   def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H :: HNil] = CompositionCons()
 }
 
-/** Compose multiple type level api descriptions in a HList of HLists.
-  */
+/** Compose multiple type level api descriptions in a HList of HLists. */
 final case class CompositionCons[H <: HList]() {
 
   def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H] = CompositionCons()

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -19,32 +19,32 @@ sealed trait PathList[P <: HList]
 final case class PathListCons[P <: HList]() extends PathList[P] {
 
   def /[S](path: Witness.Lt[S]): PathListCons[PathElement[S] :: P] = PathListCons()
-  def /[S <: Symbol, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: P] = PathListCons()
+  def /[S, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: P] = PathListCons()
 }
 
 case object PathListEmpty extends PathList[HNil] {
 
   def /[S](path: Witness.Lt[S]): PathListCons[PathElement[S] :: HNil] = PathListCons()
-  def /[S <: Symbol, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: HNil] = PathListCons()
+  def /[S, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: HNil] = PathListCons()
 }
 
 sealed trait QueryList[Q <: HList]
 
 final case class QueryListCons[Q <: HList]() extends QueryList[Q] {
 
-  def add[S <: Symbol, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: Q] = QueryListCons()
+  def add[S, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: Q] = QueryListCons()
 }
 
 case object QueryListEmpty extends QueryList[HNil] {
 
-  def add[S <: Symbol, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: HNil] = QueryListCons()
+  def add[S, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: HNil] = QueryListCons()
 }
 
 sealed trait HeaderList[H <: HList]
 
 final case class HeaderListCons[H <: HList]() extends HeaderList[H] {
 
-  def add[S <: Symbol, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: H] = HeaderListCons()
+  def add[S, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: H] = HeaderListCons()
   def add(headers: RawHeadersParam.type): RawHeaderCons[RawHeadersParam.type :: H] = RawHeaderCons()
 }
 
@@ -52,6 +52,6 @@ final case class RawHeaderCons[H <: HList]() extends HeaderList[H]
 
 case object HeaderListEmpty extends HeaderList[HNil] {
 
-  def add[S <: Symbol, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: HNil] = HeaderListCons()
+  def add[S, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: HNil] = HeaderListCons()
   def add(headers: RawHeadersParam.type): RawHeaderCons[RawHeadersParam.type :: HNil] = RawHeaderCons()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -31,16 +31,16 @@ trait ApiTransformer {
   implicit def pathElementTransformer[S, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[PathElement[S], (El, KIn, VIn, M, Out), (S :: El, KIn, VIn, M, Out)]
 
-  implicit def segmentElementTransformer[S <: Symbol, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def segmentElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[SegmentParam[S, A], (El, KIn, VIn, M, Out), (SegmentInput :: El, S :: KIn, A :: VIn, M, Out)]
 
-  implicit def queryElementTransformer[S <: Symbol, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def queryElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[QueryParam[S, A], (El, KIn, VIn, M, Out), (QueryInput :: El, S :: KIn, A :: VIn, M, Out)]
 
-  implicit def queryListElementTransformer[S <: Symbol, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def queryListElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[QueryParam[S, List[A]], (El, KIn, VIn, M, Out), (QueryInput :: El, S :: KIn, List[A] :: VIn, M, Out)]
 
-  implicit def headerElementTransformer[S <: Symbol, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def headerElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[HeaderParam[S, A], (El, KIn, VIn, M, Out), (HeaderInput :: El, S :: KIn, A :: VIn, M, Out)]
 
   implicit def rawHeadersElementTransformer[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 

--- a/shared/src/main/scala/typedapi/shared/WitnessToString.scala
+++ b/shared/src/main/scala/typedapi/shared/WitnessToString.scala
@@ -1,0 +1,17 @@
+package typedapi.shared
+
+sealed trait WitnessToString[K] {
+
+  def show(key: K): String
+}
+
+trait WitnessToStringLowPrio {
+
+  implicit def symbolKey[K <: Symbol] = new WitnessToString[K] {
+    def show(key: K): String = key.name
+  }
+
+  implicit def stringKey[K <: String] = new WitnessToString[K] {
+    def show(key: K): String = key
+  }
+}

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -40,17 +40,17 @@ object ApiDefinitionSpec {
   test.illTyped("Headers add RawHeaders add Header[Int](fooW)")
 
   // methods
-  testCompile(api(Get[Foo]))[GetElement[Foo] :: HNil]
+  testCompile(api(Get[Json, Foo]))[GetElement[`Application/Json`.type, Foo] :: HNil]
   test.illTyped("apiWothBody(Get[Foo], ReqBody[Foo])")
-  testCompile(api(Put[Foo]))[PutElement[Foo] :: HNil]
-  testCompile(apiWithBody(Put[Foo], ReqBody[Foo]))[PutWithBodyElement[Foo, Foo] :: HNil]
-  testCompile(api(Post[Foo]))[PostElement[Foo] :: HNil]
-  testCompile(apiWithBody(Post[Foo], ReqBody[Foo]))[PostWithBodyElement[Foo, Foo] :: HNil]
-  testCompile(api(Delete[Foo]))[DeleteElement[Foo] :: HNil]
-  test.illTyped("apiWothBody(Delete[Foo], ReqBody[Foo])")
+  testCompile(api(Put[Json, Foo]))[PutElement[`Application/Json`.type, Foo] :: HNil]
+  testCompile(apiWithBody(Put[Json, Foo], ReqBody[Plain, Foo]))[PutWithBodyElement[`Text/Plain`.type, Foo, `Application/Json`.type, Foo] :: HNil]
+  testCompile(api(Post[Json, Foo]))[PostElement[`Application/Json`.type, Foo] :: HNil]
+  testCompile(apiWithBody(Post[Json, Foo], ReqBody[Plain, Foo]))[PostWithBodyElement[`Text/Plain`.type, Foo, `Application/Json`.type, Foo] :: HNil]
+  testCompile(api(Delete[Json, Foo]))[DeleteElement[`Application/Json`.type, Foo] :: HNil]
+  test.illTyped("apiWothBody(Delete[Json, Foo], ReqBody[Plain, Foo])")
 
   // whole api
   testCompile(
-    api(Get[Foo], Root / "test" / Segment[Int]('foo), Queries add Query[String]('foo), Headers add Header[Double]('foo))
-  )[GetElement[Foo] :: HeaderParam[fooW.T, Double] :: QueryParam[fooW.T, String] :: SegmentParam[fooW.T, Int] :: PathElement[testW.T] :: HNil]
+    api(Get[Json, Foo], Root / "test" / Segment[Int]('foo), Queries add Query[String]('foo), Headers add Header[Double]('foo))
+  )[GetElement[`Application/Json`.type, Foo] :: HeaderParam[fooW.T, Double] :: QueryParam[fooW.T, String] :: SegmentParam[fooW.T, Int] :: PathElement[testW.T] :: HNil]
 }

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -19,13 +19,13 @@ object ApiDslSpec {
   testCompile(:= :> Segment[Int](fooW))[SegmentParam[fooW.T, Int] :: HNil]
   testCompile(:= :> Query[Int](fooW))[QueryParam[fooW.T, Int] :: HNil]
   testCompile(:= :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: HNil]
-  testCompile(:= :> Get[Foo])[GetElement[Foo] :: HNil]
+  testCompile(:= :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: HNil]
 
   // path: add every element
   testCompile(base :> Segment[Int](fooW))[SegmentParam[fooW.T, Int] :: Base]
   testCompile(base :> Query[Int](fooW))[QueryParam[fooW.T, Int] :: Base]
   testCompile(base :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: Base]
-  testCompile(base :> Get[Foo])[GetElement[Foo] :: Base]
+  testCompile(base :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: Base]
 
   // segment: add every element
   val _baseSeg = base :> Segment[Int](fooW)
@@ -35,7 +35,7 @@ object ApiDslSpec {
   testCompile(_baseSeg :> Segment[Int](fooW))[SegmentParam[fooW.T, Int] :: _BaseSeg]
   testCompile(_baseSeg :> Query[Int](fooW))[QueryParam[fooW.T, Int] :: _BaseSeg]
   testCompile(_baseSeg :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseSeg]
-  testCompile(_baseSeg :> Get[Foo])[GetElement[Foo] :: _BaseSeg]
+  testCompile(_baseSeg :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseSeg]
   
   // query: add queries, headers, body and final
   val _baseQ = base :> Query[Int](fooW)
@@ -46,7 +46,7 @@ object ApiDslSpec {
   test.illTyped("_baseQ :> Segment[Int](fooW)")
   testCompile(_baseQ :> Query[Int](fooW))[QueryParam[fooW.T, Int] :: _BaseQ]
   testCompile(_baseQ :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseQ]
-  testCompile(_baseQ :> Get[Foo])[GetElement[Foo] :: _BaseQ]
+  testCompile(_baseQ :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseQ]
   
   // header: add header, final
   val _baseH = base :> Header[Int](fooW)
@@ -57,7 +57,7 @@ object ApiDslSpec {
   test.illTyped("_baseH :> Segment[Int](fooW)")
   test.illTyped("_baseH :> Query[Int](fooW)")
   testCompile(_baseH :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseH]
-  testCompile(_baseH :> Get[Foo])[GetElement[Foo] :: _BaseH]
+  testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseH]
 
   // raw headers: add final
   val _baseRH = base :> RawHeaders
@@ -67,25 +67,25 @@ object ApiDslSpec {
   test.illTyped("_baseRH :> \"fail\"")
   test.illTyped("_baseRH :> Segment[Int](fooW)")
   test.illTyped("_baseRH :> Query[Int](fooW)")
-  testCompile(_baseRH :> Get[Foo])[GetElement[Foo] :: _BaseRH]
+  testCompile(_baseRH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseRH]
 
   // request body: add put or post
-  val _baseRB = base :> ReqBody[Foo]
+  val _baseRB = base :> ReqBody[Plain, Foo]
 
   type _BaseRB = Base
 
   test.illTyped("_baseRB :> Segment[Int](fooW)")
   test.illTyped("_baseRB :> Query[Int](fooW)")
   test.illTyped("_baseRB :> Header[Int](fooW)")
-  test.illTyped("_baseRB :> Get[Foo]")
-  testCompile(_baseRB :> Put[Foo])[PutWithBodyElement[Foo, Foo] :: _BaseRB]
-  testCompile(_baseRB :> Post[Foo])[PostWithBodyElement[Foo, Foo] :: _BaseRB]
+  test.illTyped("_baseRB :> Get[Json, Foo]")
+  testCompile(_baseRB :> Put[Json, Foo])[PutWithBodyElement[`Text/Plain`.type, Foo, `Application/Json`.type, Foo] :: _BaseRB]
+  testCompile(_baseRB :> Post[Json, Foo])[PostWithBodyElement[`Text/Plain`.type, Foo, `Application/Json`.type, Foo] :: _BaseRB]
 
   // method: nothing at all
-  val _baseF = base :> Get[Foo]
+  val _baseF = base :> Get[Json, Foo]
 
   test.illTyped("_baseF :> Segment[Int](fooW)")
   test.illTyped("_baseF :> Query[Int](fooW)")
   test.illTyped("_baseF :> Header[Int](fooW)")
-  test.illTyped("_baseF :> Get[Foo]")
+  test.illTyped("_baseF :> Get[Json, Foo]")
 }

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -1,6 +1,7 @@
 package typedapi.shared
 
 import shapeless._
+import shapeless.labelled.FieldType
 
 // compilation-only test
 final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransformer {
@@ -13,21 +14,23 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   val pathW = Witness("test")
   val fooW  = Witness('foo)
 
-  testCompile[GetElement[Foo] :: HNil, (HNil, HNil, HNil, GetCall, Foo)]
-  testCompile[PutElement[Foo] :: HNil, (HNil, HNil, HNil, PutCall, Foo)]
-  testCompile[PutWithBodyElement[Foo, Foo] :: HNil, (HNil, BodyField.T :: HNil, Foo :: HNil, PutWithBodyCall, Foo)]
-  testCompile[PostElement[Foo] :: HNil, (HNil, HNil, HNil, PostCall, Foo)]
-  testCompile[PostWithBodyElement[Foo, Foo] :: HNil, (HNil, BodyField.T :: HNil, Foo :: HNil, PostWithBodyCall, Foo)]
-  testCompile[DeleteElement[Foo] :: HNil, (HNil, HNil, HNil, DeleteCall, Foo)]
-  testCompile[GetElement[Foo] :: PathElement[pathW.T] :: HNil, (pathW.T :: HNil, HNil, HNil, GetCall, Foo)]
-  testCompile[GetElement[Foo] :: SegmentParam[fooW.T, String] :: HNil, (SegmentInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, Foo)]
-  testCompile[GetElement[Foo] :: QueryParam[fooW.T, String] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, Foo)]
-  testCompile[GetElement[Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, Foo)]
-  testCompile[GetElement[Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, Foo)]
-  testCompile[GetElement[Foo] :: RawHeadersParam.type :: HNil, (RawHeadersInput :: HNil, RawHeadersField.T :: HNil, Map[String, String] :: HNil, GetCall, Foo)]
+  type Json  = `Application/Json`.type
+
+  testCompile[GetElement[Json, Foo] :: HNil, (HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[PutElement[Json, Foo] :: HNil, (HNil, HNil, HNil, PutCall, FieldType[Json, Foo])]
+  testCompile[PutWithBodyElement[Json, Foo, Json, Foo] :: HNil, (HNil, FieldType[Json, BodyField.T] :: HNil, Foo :: HNil, PutWithBodyCall, FieldType[Json, Foo])]
+  testCompile[PostElement[Json, Foo] :: HNil, (HNil, HNil, HNil, PostCall, FieldType[Json, Foo])]
+  testCompile[PostWithBodyElement[Json, Foo, Json, Foo] :: HNil, (HNil, FieldType[Json, BodyField.T] :: HNil, Foo :: HNil, PostWithBodyCall, FieldType[Json, Foo])]
+  testCompile[DeleteElement[Json, Foo] :: HNil, (HNil, HNil, HNil, DeleteCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: PathElement[pathW.T] :: HNil, (pathW.T :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: SegmentParam[fooW.T, String] :: HNil, (SegmentInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, String] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: RawHeadersParam.type :: HNil, (RawHeadersInput :: HNil, RawHeadersField.T :: HNil, Map[String, String] :: HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[
-    GetElement[Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 
-    (pathW.T :: SegmentInput :: QueryInput :: HeaderInput :: HNil, fooW.T :: fooW.T :: fooW.T :: HNil, String :: Int :: Boolean :: HNil, GetCall, Foo)
+    GetElement[Json, Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 
+    (pathW.T :: SegmentInput :: QueryInput :: HeaderInput :: HNil, fooW.T :: fooW.T :: fooW.T :: HNil, String :: Int :: Boolean :: HNil, GetCall, FieldType[Json, Foo])
   ]
 }


### PR DESCRIPTION
So far, encodings were only set by the HTTP framework (encoder,decoder) but not present in the API. This PR changes that. Now you are able to write the following:

```Scala
val Api = := :> "users" :> "create" :> ReqBody[Json, User] :> Post[Json, User]
```