### PR TITLE
Cleanups, added FixedHeaders and removed RawHeaders

### DIFF
--- a/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
+++ b/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
@@ -78,27 +78,6 @@ trait RequestDataBuilderLowPrio {
       }
     }
 
-  implicit def fixedHeaderInputCompiler[FH <: HList, T <: HList, KIn <: HList, VIn <: HList, M <: MethodType, O]
-      (implicit fixedToMap: FixedHeadersToMap[FH], compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
-    new RequestDataBuilder[FixedHeaders[FH] :: T, KIn, VIn, M, O] {
-      type Out = compiler.Out
-
-      def apply(inputs: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        compiler(inputs, uri, queries, fixedToMap.value ++ headers)
-      }
-    }
-
-  implicit def rawHeadersInputCompiler[T <: HList, KIn <: HList, VIn <: HList, M <: MethodType, O](implicit compiler: RequestDataBuilder[T, KIn, VIn, M, O]) = 
-    new RequestDataBuilder[RawHeadersInput :: T, RawHeadersField.T :: KIn, Map[String, String] :: VIn, M, O] {
-      type Out = compiler.Out
-
-      def apply(inputs: Map[String, String] :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val headerMap = inputs.head
-
-        compiler(inputs.tail, uri, queries, headerMap ++ headers)
-      }
-    }
-
   type Data             = List[String] :: Map[String, List[String]] :: Map[String, String] :: HNil
   type DataWithBody[Bd] = List[String] :: Map[String, List[String]] :: Map[String, String] :: Bd :: HNil
 
@@ -250,6 +229,7 @@ trait RequestDataBuilderListLowPrio {
     }
 }
 
+/*
 sealed trait FixedHeadersToMap[H <: HList] {
 
   def value: Map[String, String]
@@ -269,3 +249,4 @@ object FixedHeadersToMap {
     val value = Map((keyShow.show(key), valueShow.show(value))) ++ next.value
   }
 }
+ */

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -62,6 +62,8 @@ final class RequestDataBuilderSpec extends Specification {
         val api2 = derive(:= :> Header[Option[Int]]('i0) :> Get[Json, ReqInput])
         api2(Some(0)).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
         api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
+        val api3 = derive(:= :> Fixed('i0, 'i1) :> Get[Json, ReqInput])
+        api3().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
       }
 
       "request body" >> {

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -64,11 +64,6 @@ final class RequestDataBuilderSpec extends Specification {
         api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
       }
 
-      "raw header" >> {
-        val api0 = derive(:= :> RawHeaders :> Get[Json, ReqInput])
-        api0(Map("i0" -> "0")).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
-      }
-
       "request body" >> {
         val api0 = derive(:= :> ReqBody[Json, Int] :> Put[Json, ReqInputWithBody[Int]])
         api0(0).run[Id](cm)(putB) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json"), ("Content-Type", "application/json")), 0)

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, h0, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -43,6 +43,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
     
     "headers" >> {
       h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
+      h1().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -43,7 +43,6 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
     
     "headers" >> {
       h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
-      h1(42, Map("name" -> "jim")).run[Future](cm) must beEqualTo(User("jim", 42)).awaitFor(timeout)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -31,7 +31,6 @@ final class Http4sClientSupportSpec extends Specification {
     
     "headers" >> {
       h0(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
-      h1(42, Map("name" -> "jim")).run[IO](cm).unsafeRunSync() === User("jim", 42)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -31,6 +31,7 @@ final class Http4sClientSupportSpec extends Specification {
     
     "headers" >> {
       h0(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
+      h1().run[IO](cm).unsafeRunSync() === User("joe", 27)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -32,6 +32,15 @@ object TestServer {
 
       Ok(User("foo", age))
 
+    case req @ GET -> Root / "header" / "fixed" => 
+      val headers = req.headers.toList
+      val value   = headers.find(_.name.value == "Hello").get.value
+
+      if (value != "*")
+        throw new IllegalArgumentException("unexpected header value " + value)
+
+      Ok(User("joe", 27))
+
     case GET -> Root => Ok(User("foo", 27))
     case PUT -> Root => Ok(User("foo", 27))
     case req @ PUT -> Root / "body" => Ok(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -32,13 +32,6 @@ object TestServer {
 
       Ok(User("foo", age))
 
-    case req @ GET -> Root / "header" / "raw" => 
-      val headers = req.headers.toList
-      val name    = headers.find(_.name.value == "name").get.value
-      val age     = headers.find(_.name.value == "age").get.value.toInt
-
-      Ok(User(name, age))
-
     case GET -> Root => Ok(User("foo", 27))
     case PUT -> Root => Ok(User("foo", 27))
     case req @ PUT -> Root / "body" => Ok(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -9,6 +9,7 @@ package object tests {
     (:= :> "segment" :> Segment[String]('name) :> Get[Json, User]) :|:
     (:= :> "query" :> Query[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> Header[Int]('age) :> Get[Json, User]) :|:
+    (:= :> "header" :> "fixed" :> Fixed("Hello", "*") :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:
     (:= :> Put[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -9,7 +9,6 @@ package object tests {
     (:= :> "segment" :> Segment[String]('name) :> Get[Json, User]) :|:
     (:= :> "query" :> Query[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> Header[Int]('age) :> Get[Json, User]) :|:
-    (:= :> "header" :> "raw" :> Header[Int]('age) :> RawHeaders :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:
     (:= :> Put[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, raw, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, get, put, putB, post, postB, delete)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, raw, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, get, put, putB, post, postB, delete)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -36,6 +36,11 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
         uri = Uri.fromString(s"http://localhost:$port/header").right.get,
         headers = Headers(Header("age", "42"))
       )).unsafeRunSync() === User("joe", 42)
+      client.expect[User](Request[IO](
+        method = GET,
+        uri = Uri.fromString(s"http://localhost:$port/header/fixed").right.get,
+        headers = Headers(Header("Hello", "*"))
+      )).unsafeRunSync() === User("joe", 27)
     }
 
     "methods" >> {
@@ -52,6 +57,7 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
   val segment: String => F[User] = name => Applicative[F].pure(User(name, 27))
   val query: Int => F[User] = age => Applicative[F].pure(User("joe", age))
   val header: Int => F[User] = age => Applicative[F].pure(User("joe", age))
+  val fixed: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val get: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val put: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val putB: User => F[User] = user => Applicative[F].pure(user)

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -36,11 +36,6 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
         uri = Uri.fromString(s"http://localhost:$port/header").right.get,
         headers = Headers(Header("age", "42"))
       )).unsafeRunSync() === User("joe", 42)
-      client.expect[User](Request[IO](
-        method = GET,
-        uri = Uri.fromString(s"http://localhost:$port/header/raw").right.get,
-        headers = Headers(Header("age", "42"), Header("name", "jim"))
-      )).unsafeRunSync() === User("jim", 42)
     }
 
     "methods" >> {
@@ -57,7 +52,6 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
   val segment: String => F[User] = name => Applicative[F].pure(User(name, 27))
   val query: Int => F[User] = age => Applicative[F].pure(User("joe", age))
   val header: Int => F[User] = age => Applicative[F].pure(User("joe", age))
-  val raw: (Int, Map[String, String]) => F[User] = (age, nameM) => Applicative[F].pure(User(nameM("name"), age))
   val get: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val put: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val putB: User => F[User] = user => Applicative[F].pure(user)

--- a/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
+++ b/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
@@ -86,7 +86,7 @@ package object http4s {
               else              path.tail.toList
             },
             request.uri.multiParams.map { case (key, value) => key -> value.toList },
-            request.headers.toList.map(header => header.name.toString -> header.value)(collection.breakOut)
+            request.headers.toList.map(header => header.name.toString.toLowerCase -> header.value)(collection.breakOut)
           )
           execute(endpoints, eReq)
       }

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -163,21 +163,6 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
       }
     }
 
-  implicit def rawHeaderExtractor[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
-      (implicit next: RouteExtractor[El, KIn, VIn, M, shapeless.::[Map[String, String], EIn]]) =
-    new RouteExtractor[shapeless.::[RawHeadersInput, El], shapeless.::[RawHeadersField.T, KIn], shapeless.::[Map[String, String], VIn], M, EIn] {
-      type Out = next.Out
-
-      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-        val raw = req.headers.filterKeys(!extractedHeaderKeys(_))
-
-        if (raw.isEmpty)
-          BadRequestE("no raw headers left, but at least one expected")
-        else
-          next(request.copy(headers = Map.empty), extractedHeaderKeys, raw :: inAgg)
-      }
-    }
-
   implicit def getExtractor[EIn <: HList, REIn <: HList](implicit rev: Reverse.Aux[EIn, REIn]) = new RouteExtractor[HNil, HNil, HNil, GetCall, EIn] {
     type Out = REIn
 

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -62,10 +62,16 @@ final class RouteExtractorSpec extends Specification {
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'age'")
       ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
-      val ext3 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Json, Foo])
+      val ext2 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Json, Foo])
 
-      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(Some(0) :: HNil)
-      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(None :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(Some(0) :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(None :: HNil)
+
+      val ext3 = extract(:= :> "foo" :> Fixed("Accept", "*") :> Get[Json, Foo])
+
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
     }
 
     "body type" >> {

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -62,18 +62,6 @@ final class RouteExtractorSpec extends Specification {
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'age'")
       ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
-      //raw
-      val ext1 = extract(:= :> "foo" :> RawHeaders :> Get[Json, Foo])
-
-      ext1(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "blah")), Set.empty, HNil) === Right(Map("age" -> "blah") :: HNil)
-      ext1(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("no raw headers left, but at least one expected")
-
-      // headers and raw
-      val ext2 = extract(:= :> "foo" :> Header[Int]('age) :> RawHeaders :> Get[Json, Foo])
-
-      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === RouteExtractor.BadRequestE("no raw headers left, but at least one expected")
-      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0", "foo" -> "bar")), Set.empty, HNil) === Right(0 :: Map("foo" -> "bar") :: HNil)
-
       val ext3 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Json, Foo])
 
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(Some(0) :: HNil)

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -17,7 +17,6 @@ sealed trait ApiList[H <: HList]
 /** Basic operations. */
 sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
 
-  def :>(headers: RawHeadersParam.type): RawHeadersCons[RawHeadersParam.type :: H] = RawHeadersCons()
   def :>[MT <: MediaType, A](body: ReqBodyElement[MT, A]): WithBodyCons[MT, A, H] = WithBodyCons()
   def :>[MT <: MediaType, A](get: GetElement[MT, A]): ApiTypeCarrier[GetElement[MT, A] :: H] = ApiTypeCarrier()
   def :>[MT <: MediaType, A](put: PutElement[MT, A]): ApiTypeCarrier[PutElement[MT, A] :: H] = ApiTypeCarrier()
@@ -29,45 +28,41 @@ sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
 case object EmptyCons extends ApiListWithOps[HNil] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: HNil] = PathCons()
-  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: HNil] = SegmentCons()
-  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: HNil] = QueryCons()  
-  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: HNil] = HeaderCons()
+  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: HNil] = SegmentCons()
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: HNil] = QueryCons()  
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: HNil] = HeaderCons()
 }
 
 /** Last set element is a path. */
 final case class PathCons[H <: HList]() extends ApiListWithOps[H] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
-  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()  
-  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()  
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
 }
 
 /** Last set element is a segment. */
 final case class SegmentCons[H <: HList]() extends ApiListWithOps[H] {
 
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[S, A](segment: SegmentParam[S, A]): SegmentCons[SegmentParam[S, A] :: H] = SegmentCons()
-  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
-  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
 }
 
 /** Last set element is a query parameter. */
 final case class QueryCons[H <: HList]() extends ApiListWithOps[H]  {
 
-  def :>[S, A](query: QueryParam[S, A]): QueryCons[QueryParam[S, A] :: H] = QueryCons()
-  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
 }
 
 /** Last set element is a header. */
 final case class HeaderCons[H <: HList]() extends ApiListWithOps[H] {
 
-  def :>[S, A](header: HeaderParam[S, A]): HeaderCons[HeaderParam[S, A] :: H] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
 }
-
-/** Last set element is a header. */
-final case class RawHeadersCons[H <: HList]() extends ApiListWithOps[H]
-
 
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -27,7 +27,8 @@ case object EmptyCons extends ApiListWithOps[HNil] {
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: HNil] = PathCons()
   def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: HNil] = SegmentCons()
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: HNil] = QueryCons()  
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: HNil] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: HNil] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: HNil] = FixedHeaderCons()
 }
 
 /** Last set element is a path. */
@@ -36,7 +37,8 @@ final case class PathCons[H <: HList]() extends ApiListWithOps[H] {
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
   def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()  
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
 }
 
 /** Last set element is a segment. */
@@ -45,21 +47,27 @@ final case class SegmentCons[H <: HList]() extends ApiListWithOps[H] {
   def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
   def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
 }
 
 /** Last set element is a query parameter. */
 final case class QueryCons[H <: HList]() extends ApiListWithOps[H]  {
 
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
 }
 
 /** Last set element is a header. */
-final case class HeaderCons[H <: HList]() extends ApiListWithOps[H] {
+sealed trait HeaderCons[H <: HList] extends ApiListWithOps[H] {
 
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): HeaderCons[HeaderParam[K, V] :: H] = HeaderCons()
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
 }
+
+final case class InputHeaderCons[H <: HList]() extends HeaderCons[H]
+final case class FixedHeaderCons[H <: HList]() extends HeaderCons[H]
 
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -17,11 +17,8 @@ sealed trait ApiList[H <: HList]
 /** Basic operations. */
 sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
 
-  def :>[MT <: MediaType, A](body: ReqBodyElement[MT, A]): WithBodyCons[MT, A, H] = WithBodyCons()
-  def :>[MT <: MediaType, A](get: GetElement[MT, A]): ApiTypeCarrier[GetElement[MT, A] :: H] = ApiTypeCarrier()
-  def :>[MT <: MediaType, A](put: PutElement[MT, A]): ApiTypeCarrier[PutElement[MT, A] :: H] = ApiTypeCarrier()
-  def :>[MT <: MediaType, A](post: PostElement[MT, A]): ApiTypeCarrier[PostElement[MT, A] :: H] = ApiTypeCarrier()
-  def :>[MT <: MediaType, A](delete: DeleteElement[MT, A]): ApiTypeCarrier[DeleteElement[MT, A] :: H] = ApiTypeCarrier()
+  def :>[MT <: MediaType, A](body: TypeCarrier[ReqBodyElement[MT, A]]): WithBodyCons[MT, A, H] = WithBodyCons()
+  def :>[M <: MethodElement](method: TypeCarrier[M]): ApiTypeCarrier[M :: H] = ApiTypeCarrier()
 }
 
 /** Initial element with empty api description. */
@@ -67,6 +64,5 @@ final case class HeaderCons[H <: HList]() extends ApiListWithOps[H] {
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {
 
-  def :>[MT <: MediaType, A](put: PutElement[MT, A]): ApiTypeCarrier[PutWithBodyElement[BMT, Bd, MT, A] :: H] = ApiTypeCarrier()
-  def :>[MT <: MediaType, A](post: PostElement[MT, A]): ApiTypeCarrier[PostWithBodyElement[BMT, Bd, MT, A] :: H] = ApiTypeCarrier()
+  def :>[M <: MethodElement](method: TypeCarrier[M])(implicit out: MethodToReqBody[M, BMT, Bd]): ApiTypeCarrier[out.Out :: H] = ApiTypeCarrier()
 }

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -9,6 +9,7 @@ package object dsl {
   def Segment[V] = new PairTypeFromWitnessKey[SegmentParam, V]
   def Query[V]   = new PairTypeFromWitnessKey[QueryParam, V]
   def Header[V]  = new PairTypeFromWitnessKey[HeaderParam, V]
+  def Fixed      = new PairTypeFromWitnesses[FixedHeaderElement]
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -1,18 +1,16 @@
 package typedapi
 
 import typedapi.shared._
-import shapeless.{Witness, HNil}
+import shapeless.Witness
 
 package object dsl {
 
   def := = EmptyCons
 
   def Path[S](wit: Witness.Lt[S]) = PathElement[S](wit)
-  def Segment[A]                  = new SegmentHelper[A]
-  def Query[A]                    = new QueryHelper[A]
-  def Header[A]                   = new HeaderHelper[A]
-  val FixedHeaders                = new FixedHeadersHelper[HNil]()
-  val RawHeaders                  = RawHeadersParam
+  def Segment[V]                  = new PairTypeFromWitnessKey[SegmentParam, V]
+  def Query[V]                    = new PairTypeFromWitnessKey[QueryParam, V]
+  def Header[V]                   = new PairTypeFromWitnessKey[HeaderParam, V]
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -1,17 +1,18 @@
 package typedapi
 
 import typedapi.shared._
-import shapeless.Witness
+import shapeless.{Witness, HNil}
 
 package object dsl {
 
   def := = EmptyCons
 
   def Path[S](wit: Witness.Lt[S]) = PathElement[S](wit)
-  def Segment[A] = new SegmentHelper[A]
-  def Query[A]   = new QueryHelper[A]
-  def Header[A]  = new HeaderHelper[A]
-  val RawHeaders = RawHeadersParam
+  def Segment[A]                  = new SegmentHelper[A]
+  def Query[A]                    = new QueryHelper[A]
+  def Header[A]                   = new HeaderHelper[A]
+  val FixedHeaders                = new FixedHeadersHelper[HNil]()
+  val RawHeaders                  = RawHeadersParam
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -1,23 +1,21 @@
 package typedapi
 
 import typedapi.shared._
-import shapeless.Witness
 
 package object dsl {
 
   def := = EmptyCons
 
-  def Path[S](wit: Witness.Lt[S]) = PathElement[S](wit)
-  def Segment[V]                  = new PairTypeFromWitnessKey[SegmentParam, V]
-  def Query[V]                    = new PairTypeFromWitnessKey[QueryParam, V]
-  def Header[V]                   = new PairTypeFromWitnessKey[HeaderParam, V]
+  def Segment[V] = new PairTypeFromWitnessKey[SegmentParam, V]
+  def Query[V]   = new PairTypeFromWitnessKey[QueryParam, V]
+  def Header[V]  = new PairTypeFromWitnessKey[HeaderParam, V]
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type
 
-  def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
-  def Get[MT <: MediaType, A] = GetElement[MT, A]
-  def Put[MT <: MediaType, A] = PutElement[MT, A]
-  def Post[MT <: MediaType, A] = PostElement[MT, A]
-  def Delete[MT <: MediaType, A] = DeleteElement[MT, A]
+  def ReqBody[MT <: MediaType, A] = TypeCarrier[ReqBodyElement[MT, A]]()
+  def Get[MT <: MediaType, A]     = TypeCarrier[GetElement[MT, A]]()
+  def Put[MT <: MediaType, A]     = TypeCarrier[PutElement[MT, A]]()
+  def Post[MT <: MediaType, A]    = TypeCarrier[PostElement[MT, A]]()
+  def Delete[MT <: MediaType, A]  = TypeCarrier[DeleteElement[MT, A]]()
 }

--- a/shared/src/main/scala/typedapi/package.scala
+++ b/shared/src/main/scala/typedapi/package.scala
@@ -14,20 +14,20 @@ package object typedapi extends MethodToReqBodyLowPrio {
   val Headers      = HeaderListBuilder[HNil]()
   val NoHeaders    = Headers
 
-  def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
-  def Get[MT <: MediaType, A]     = GetElement[MT, A]
-  def Put[MT <: MediaType, A]     = PutElement[MT, A]
-  def Post[MT <: MediaType, A]    = PostElement[MT, A]
-  def Delete[MT <: MediaType, A]  = DeleteElement[MT, A]
+  def ReqBody[MT <: MediaType, A] = TypeCarrier[ReqBodyElement[MT, A]]()
+  def Get[MT <: MediaType, A]     = TypeCarrier[GetElement[MT, A]]()
+  def Put[MT <: MediaType, A]     = TypeCarrier[PutElement[MT, A]]()
+  def Post[MT <: MediaType, A]    = TypeCarrier[PostElement[MT, A]]()
+  def Delete[MT <: MediaType, A]  = TypeCarrier[DeleteElement[MT, A]]()
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type
 
   def api[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList]
-      (method: M, path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
+      (method: TypeCarrier[M], path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
       (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api]): ApiTypeCarrier[M :: Api] = ApiTypeCarrier()
 
   def apiWithBody[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList, BMT <: MediaType, Bd]
-      (method: M, body: ReqBodyElement[BMT, Bd], path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
+      (method: TypeCarrier[M], body: TypeCarrier[ReqBodyElement[BMT, Bd]], path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
       (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api], m: MethodToReqBody[M, BMT, Bd]): ApiTypeCarrier[m.Out :: Api] = ApiTypeCarrier()
 }

--- a/shared/src/main/scala/typedapi/package.scala
+++ b/shared/src/main/scala/typedapi/package.scala
@@ -12,10 +12,11 @@ package object typedapi extends MethodToReqBodyLowPrio {
   val NoQueries = Queries
   def Query[A]  = new QueryHelper[A]
 
-  val Headers    = HeaderListEmpty
-  val NoHeaders  = Headers
-  def Header[A]  = new HeaderHelper[A]
-  val RawHeaders = RawHeadersParam
+  val Headers      = HeaderListCons[HNil]
+  val NoHeaders    = Headers
+  def Header[A]    = new HeaderHelper[A]
+  val FixedHeaders = new FixedHeadersHelper[HNil]()
+  val RawHeaders   = RawHeadersParam
 
   def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
   def Get[MT <: MediaType, A]     = GetElement[MT, A]

--- a/shared/src/main/scala/typedapi/package.scala
+++ b/shared/src/main/scala/typedapi/package.scala
@@ -6,17 +6,13 @@ import shapeless.ops.hlist.Prepend
 package object typedapi extends MethodToReqBodyLowPrio {
 
   val Root       = PathListEmpty
-  def Segment[A] = new SegmentHelper[A]
+  def Segment[V] = new PairTypeFromWitnessKey[SegmentParam, V]
 
-  val Queries   = QueryListEmpty
+  val Queries   = QueryListBuilder[HNil]()
   val NoQueries = Queries
-  def Query[A]  = new QueryHelper[A]
 
-  val Headers      = HeaderListCons[HNil]
+  val Headers      = HeaderListBuilder[HNil]()
   val NoHeaders    = Headers
-  def Header[A]    = new HeaderHelper[A]
-  val FixedHeaders = new FixedHeadersHelper[HNil]()
-  val RawHeaders   = RawHeadersParam
 
   def ReqBody[MT <: MediaType, A] = ReqBodyElement[MT, A]
   def Get[MT <: MediaType, A]     = GetElement[MT, A]
@@ -28,10 +24,10 @@ package object typedapi extends MethodToReqBodyLowPrio {
   type Plain = `Text/Plain`.type
 
   def api[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList]
-      (method: M, path: PathList[P] = Root, queries: QueryList[Q] = NoQueries, headers: HeaderList[H] = NoHeaders)
+      (method: M, path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
       (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api]): ApiTypeCarrier[M :: Api] = ApiTypeCarrier()
 
   def apiWithBody[M <: MethodElement, P <: HList, Q <: HList, H <: HList, Prep <: HList, Api <: HList, BMT <: MediaType, Bd]
-      (method: M, body: ReqBodyElement[BMT, Bd], path: PathList[P] = Root, queries: QueryList[Q] = NoQueries, headers: HeaderList[H] = NoHeaders)
+      (method: M, body: ReqBodyElement[BMT, Bd], path: PathList[P] = Root, queries: QueryListBuilder[Q] = NoQueries, headers: HeaderListBuilder[H] = NoHeaders)
       (implicit prepQP: Prepend.Aux[Q, P, Prep], prepH: Prepend.Aux[H, Prep, Api], m: MethodToReqBody[M, BMT, Bd]): ApiTypeCarrier[m.Out :: Api] = ApiTypeCarrier()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -1,6 +1,6 @@
 package typedapi.shared
 
-import shapeless.Witness
+import shapeless._
 
 import scala.annotation.implicitNotFound
 
@@ -51,6 +51,14 @@ final class HeaderHelper[A] {
   */
 case object RawHeadersParam extends ApiElement
 
+final case class FixedHeadersElement[H <: HList]() extends ApiElement
+
+final class FixedHeadersHelper[H <: HList] {
+
+  def add[K, V](key: Witness.Lt[K], value: Witness.Lt[V]): FixedHeadersHelper[(K, V) :: HNil] = 
+    new FixedHeadersHelper
+}
+
 /** Request body type description. */
 final case class ReqBodyElement[MT <: MediaType, A]() extends ApiElement
 
@@ -83,7 +91,6 @@ trait MethodToReqBodyLowPrio {
 }
 
 trait MediaType {
-
   def value: String
 }
 case object `Application/Json` extends MediaType {

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -1,7 +1,5 @@
 package typedapi.shared
 
-import shapeless._
-
 import scala.annotation.implicitNotFound
 
 sealed trait ApiElement
@@ -10,36 +8,27 @@ sealed trait ApiElement
   * 
   * @param wit singleton type of static path element
   */
-final case class PathElement[S](wit: Witness.Lt[S]) extends ApiElement
+sealed trait PathElement[P]
 
-/** Dynamically set segment within an URI which has a unique name to reference it on input.
-  * 
-  * @param name unique name reference
-  */
+/** Dynamically set segment within an URI which has a unique name to reference it on input. */
 sealed trait SegmentParam[K, V] extends ApiElement
 
-/** Query parameter which represents its key as singleton type and describes the value type.
-  * 
-  * @param name query key
-  */
+/** Query parameter which represents its key as singleton type and describes the value type. */
 sealed trait QueryParam[K, V] extends ApiElement
 
-/** Header which represents its key as singleton type and describes the value type.
-  * 
-  * @param name header key
-  */
+/** Header which represents its key as singleton type and describes the value type. */
 sealed trait HeaderParam[K, V] extends ApiElement
 
 /** Request body type description. */
-final case class ReqBodyElement[MT <: MediaType, A]() extends ApiElement
+sealed trait ReqBodyElement[MT <: MediaType, A] extends ApiElement
 
 trait MethodElement extends ApiElement
-final case class GetElement[MT <: MediaType, A]() extends MethodElement
-final case class PutElement[MT <: MediaType, A]() extends MethodElement
-final case class PutWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A]() extends MethodElement
-final case class PostElement[MT <: MediaType, A]() extends MethodElement
-final case class PostWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A]() extends MethodElement
-final case class DeleteElement[MT <: MediaType, A]() extends MethodElement
+sealed trait GetElement[MT <: MediaType, A] extends MethodElement
+sealed trait PutElement[MT <: MediaType, A] extends MethodElement
+sealed trait PutWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A] extends MethodElement
+sealed trait PostElement[MT <: MediaType, A] extends MethodElement
+sealed trait PostWithBodyElement[BMT <: MediaType, Bd, MT <: MediaType, A] extends MethodElement
+sealed trait DeleteElement[MT <: MediaType, A] extends MethodElement
 
 @implicitNotFound("""You try to add a request body to a method which doesn't expect one.
 

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -16,48 +16,19 @@ final case class PathElement[S](wit: Witness.Lt[S]) extends ApiElement
   * 
   * @param name unique name reference
   */
-final case class SegmentParam[S, A](name: Witness.Lt[S]) extends ApiElement
-
-final class SegmentHelper[A] {
-
-  def apply[S](wit: Witness.Lt[S]) = SegmentParam[S, A](wit)
-}
+sealed trait SegmentParam[K, V] extends ApiElement
 
 /** Query parameter which represents its key as singleton type and describes the value type.
   * 
   * @param name query key
   */
-final case class QueryParam[S, A](name: Witness.Lt[S]) extends ApiElement
-
-final class QueryHelper[A] {
-
-  def apply[S](wit: Witness.Lt[S]) = QueryParam[S, A](wit)
-}
+sealed trait QueryParam[K, V] extends ApiElement
 
 /** Header which represents its key as singleton type and describes the value type.
   * 
   * @param name header key
   */
-final case class HeaderParam[S, A](name: Witness.Lt[S]) extends ApiElement
-
-final class HeaderHelper[A] {
-
-  def apply[S](wit: Witness.Lt[S]) = HeaderParam[S, A](wit)
-}
-
-/** Convenience class to add headers as `Map[String, String]` patch. This class cannot guarantee type safety.
-  * 
-  * @param headers
-  */
-case object RawHeadersParam extends ApiElement
-
-final case class FixedHeadersElement[H <: HList]() extends ApiElement
-
-final class FixedHeadersHelper[H <: HList] {
-
-  def add[K, V](key: Witness.Lt[K], value: Witness.Lt[V]): FixedHeadersHelper[(K, V) :: HNil] = 
-    new FixedHeadersHelper
-}
+sealed trait HeaderParam[K, V] extends ApiElement
 
 /** Request body type description. */
 final case class ReqBodyElement[MT <: MediaType, A]() extends ApiElement

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -19,6 +19,8 @@ sealed trait QueryParam[K, V] extends ApiElement
 /** Header which represents its key as singleton type and describes the value type. */
 sealed trait HeaderParam[K, V] extends ApiElement
 
+sealed trait FixedHeaderElement[K, V] extends ApiElement
+
 /** Request body type description. */
 sealed trait ReqBodyElement[MT <: MediaType, A] extends ApiElement
 

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -45,13 +45,8 @@ sealed trait HeaderList[H <: HList]
 final case class HeaderListCons[H <: HList]() extends HeaderList[H] {
 
   def add[S, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: H] = HeaderListCons()
+  def add[FH <: HList](fixed: FixedHeadersHelper[FH]): HeaderListCons[FixedHeadersElement[FH] :: H] = HeaderListCons()
   def add(headers: RawHeadersParam.type): RawHeaderCons[RawHeadersParam.type :: H] = RawHeaderCons()
 }
 
 final case class RawHeaderCons[H <: HList]() extends HeaderList[H]
-
-case object HeaderListEmpty extends HeaderList[HNil] {
-
-  def add[S, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: HNil] = HeaderListCons()
-  def add(headers: RawHeadersParam.type): RawHeaderCons[RawHeadersParam.type :: HNil] = RawHeaderCons()
-}

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -2,51 +2,34 @@ package typedapi.shared
 
 import shapeless._
 
-/** A final element is a method describing the request type. */
-final case class ApiTypeCarrier[H <: HList]() {
-
-  def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H :: HNil] = CompositionCons()
-}
-
-/** Compose multiple type level api descriptions in a HList of HLists. */
-final case class CompositionCons[H <: HList]() {
-
-  def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H] = CompositionCons()
-}
-
 sealed trait PathList[P <: HList]
 
 final case class PathListCons[P <: HList]() extends PathList[P] {
 
   def /[S](path: Witness.Lt[S]): PathListCons[PathElement[S] :: P] = PathListCons()
-  def /[S, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: P] = PathListCons()
+  def /[K, V](segment: TypeCarrier[SegmentParam[K, V]]): PathListCons[SegmentParam[K, V] :: P] = PathListCons()
 }
 
 case object PathListEmpty extends PathList[HNil] {
 
   def /[S](path: Witness.Lt[S]): PathListCons[PathElement[S] :: HNil] = PathListCons()
-  def /[S, A](segment: SegmentParam[S, A]): PathListCons[SegmentParam[S, A] :: HNil] = PathListCons()
+  def /[K, V](segment: TypeCarrier[SegmentParam[K, V]]): PathListCons[SegmentParam[K, V] :: HNil] = PathListCons()
 }
 
-sealed trait QueryList[Q <: HList]
+final case class QueryListBuilder[Q <: HList]() {
 
-final case class QueryListCons[Q <: HList]() extends QueryList[Q] {
+  final class WitnessDerivation[V] {
+    def apply[K](wit: Witness.Lt[K]): QueryListBuilder[QueryParam[K, V] :: Q] = QueryListBuilder()
+  }
 
-  def add[S, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: Q] = QueryListCons()
+  def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
 }
 
-case object QueryListEmpty extends QueryList[HNil] {
+final case class HeaderListBuilder[H <: HList]() {
 
-  def add[S, A](query: QueryParam[S, A]): QueryListCons[QueryParam[S, A] :: HNil] = QueryListCons()
+  final class WitnessDerivation[V] {
+    def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[HeaderParam[K, V] :: H] = HeaderListBuilder()
+  }
+
+  def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
 }
-
-sealed trait HeaderList[H <: HList]
-
-final case class HeaderListCons[H <: HList]() extends HeaderList[H] {
-
-  def add[S, A](header: HeaderParam[S, A]): HeaderListCons[HeaderParam[S, A] :: H] = HeaderListCons()
-  def add[FH <: HList](fixed: FixedHeadersHelper[FH]): HeaderListCons[FixedHeadersElement[FH] :: H] = HeaderListCons()
-  def add(headers: RawHeadersParam.type): RawHeaderCons[RawHeadersParam.type :: H] = RawHeaderCons()
-}
-
-final case class RawHeaderCons[H <: HList]() extends HeaderList[H]

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -32,4 +32,5 @@ final case class HeaderListBuilder[H <: HList]() {
   }
 
   def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
+  def add[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[FixedHeaderElement[K, V] :: H] = HeaderListBuilder()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -5,6 +5,8 @@ import shapeless.labelled.FieldType
 
 trait ApiOp
 
+sealed trait FixedHeaders[H <: HList] extends ApiOp
+
 sealed trait SegmentInput extends ApiOp
 sealed trait QueryInput extends ApiOp
 sealed trait HeaderInput extends ApiOp
@@ -42,6 +44,9 @@ trait ApiTransformer {
 
   implicit def headerElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[HeaderParam[S, A], (El, KIn, VIn, M, Out), (HeaderInput :: El, S :: KIn, A :: VIn, M, Out)]
+
+  implicit def fixedHeaderElementTransformer[H <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[FixedHeadersElement[H], (El, KIn, VIn, M, Out), (FixedHeaders[H] :: El, KIn, VIn, M, Out)]
 
   implicit def rawHeadersElementTransformer[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[RawHeadersParam.type, (El, KIn, VIn, M, Out), (RawHeadersInput :: El, RawHeadersField.T :: KIn, Map[String, String] :: VIn, M, Out)]

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -5,8 +5,6 @@ import shapeless.labelled.FieldType
 
 trait ApiOp
 
-sealed trait FixedHeaders[H <: HList] extends ApiOp
-
 sealed trait SegmentInput extends ApiOp
 sealed trait QueryInput extends ApiOp
 sealed trait HeaderInput extends ApiOp
@@ -44,12 +42,6 @@ trait ApiTransformer {
 
   implicit def headerElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[HeaderParam[S, A], (El, KIn, VIn, M, Out), (HeaderInput :: El, S :: KIn, A :: VIn, M, Out)]
-
-  implicit def fixedHeaderElementTransformer[H <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
-    at[FixedHeadersElement[H], (El, KIn, VIn, M, Out), (FixedHeaders[H] :: El, KIn, VIn, M, Out)]
-
-  implicit def rawHeadersElementTransformer[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
-    at[RawHeadersParam.type, (El, KIn, VIn, M, Out), (RawHeadersInput :: El, RawHeadersField.T :: KIn, Map[String, String] :: VIn, M, Out)]
 
   implicit def getTransformer[MT <: MediaType, A] = at[GetElement[MT, A], Unit, (HNil, HNil, HNil, GetCall, FieldType[MT, A])]
 

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -8,7 +8,8 @@ trait ApiOp
 sealed trait SegmentInput extends ApiOp
 sealed trait QueryInput extends ApiOp
 sealed trait HeaderInput extends ApiOp
-sealed trait RawHeadersInput extends ApiOp
+
+sealed trait FixedHeader[K, V] extends ApiOp
 
 trait MethodType extends ApiOp
 sealed trait GetCall extends MethodType
@@ -42,6 +43,9 @@ trait ApiTransformer {
 
   implicit def headerElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[HeaderParam[S, A], (El, KIn, VIn, M, Out), (HeaderInput :: El, S :: KIn, A :: VIn, M, Out)]
+
+  implicit def fixedHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[FixedHeaderElement[K, V], (El, KIn, VIn, M, Out), (FixedHeader[K, V] :: El, KIn, VIn, M, Out)]
 
   implicit def getTransformer[MT <: MediaType, A] = at[GetElement[MT, A], Unit, (HNil, HNil, HNil, GetCall, FieldType[MT, A])]
 

--- a/shared/src/main/scala/typedapi/shared/TypeCarrier.scala
+++ b/shared/src/main/scala/typedapi/shared/TypeCarrier.scala
@@ -11,6 +11,11 @@ final class PairTypeFromWitnessKey[F[_, _], V] {
   def apply[K](wit: Witness.Lt[K]): TypeCarrier[F[K, V]] = TypeCarrier()
 }
 
+final class PairTypeFromWitnesses[F[_, _]] {
+
+  def apply[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): TypeCarrier[F[K, V]] = TypeCarrier()
+}
+
 /** carriers the final api type, which is represented as `HList` */
 final case class ApiTypeCarrier[H <: HList]() {
 

--- a/shared/src/main/scala/typedapi/shared/TypeCarrier.scala
+++ b/shared/src/main/scala/typedapi/shared/TypeCarrier.scala
@@ -1,0 +1,24 @@
+package typedapi.shared
+
+import shapeless._
+
+import scala.language.higherKinds
+
+final case class TypeCarrier[A]()
+
+final class PairTypeFromWitnessKey[F[_, _], V] {
+
+  def apply[K](wit: Witness.Lt[K]): TypeCarrier[F[K, V]] = TypeCarrier()
+}
+
+/** carriers the final api type, which is represented as `HList` */
+final case class ApiTypeCarrier[H <: HList]() {
+
+  def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H :: HNil] = CompositionCons()
+}
+
+/** carriers multiple api types represented as `HList`; therefore, it is a `HList` of `HList` */
+final case class CompositionCons[H <: HList]() {
+
+  def :|:[H1 <: HList](next: ApiTypeCarrier[H1]): CompositionCons[H1 :: H] = CompositionCons()
+}

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -35,6 +35,7 @@ object ApiDefinitionSpec {
   testCompile(Headers add Header[Int](fooW) add Header[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
 
   // raw headers
+  testCompile(Headers add FixedHeaders.add("test", "test2"))[FixedHeadersElement[(testW.T, test2W.T) :: HNil] :: HNil]
   testCompile(Headers add RawHeaders)[RawHeadersParam.type :: HNil]
   testCompile(Headers add Header[Int](fooW) add RawHeaders)[RawHeadersParam.type :: HeaderParam[fooW.T, Int] :: HNil]
   test.illTyped("Headers add RawHeaders add Header[Int](fooW)")

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -33,6 +33,7 @@ object ApiDefinitionSpec {
   testCompile(Headers)[HNil]
   testCompile(Headers add[Int](fooW))[HeaderParam[fooW.T, Int] :: HNil]
   testCompile(Headers add[Int](fooW) add[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
+  testCompile(Headers add(fooW, testW))[FixedHeaderElement[fooW.T, testW.T] :: HNil]
 
   // methods
   testCompile(api(Get[Json, Foo]))[GetElement[`Application/Json`.type, Foo] :: HNil]

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -26,19 +26,13 @@ object ApiDefinitionSpec {
 
   // query lists
   testCompile(Queries)[HNil]
-  testCompile(Queries add Query[Int](fooW))[QueryParam[fooW.T, Int] :: HNil]
-  testCompile(Queries add Query[Int](fooW) add Query[Int](barW))[QueryParam[barW.T, Int] :: QueryParam[fooW.T, Int] :: HNil]
+  testCompile(Queries add[Int](fooW))[QueryParam[fooW.T, Int] :: HNil]
+  testCompile(Queries add[Int](fooW) add[Int](barW))[QueryParam[barW.T, Int] :: QueryParam[fooW.T, Int] :: HNil]
 
   // header lists
   testCompile(Headers)[HNil]
-  testCompile(Headers add Header[Int](fooW))[HeaderParam[fooW.T, Int] :: HNil]
-  testCompile(Headers add Header[Int](fooW) add Header[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
-
-  // raw headers
-  testCompile(Headers add FixedHeaders.add("test", "test2"))[FixedHeadersElement[(testW.T, test2W.T) :: HNil] :: HNil]
-  testCompile(Headers add RawHeaders)[RawHeadersParam.type :: HNil]
-  testCompile(Headers add Header[Int](fooW) add RawHeaders)[RawHeadersParam.type :: HeaderParam[fooW.T, Int] :: HNil]
-  test.illTyped("Headers add RawHeaders add Header[Int](fooW)")
+  testCompile(Headers add[Int](fooW))[HeaderParam[fooW.T, Int] :: HNil]
+  testCompile(Headers add[Int](fooW) add[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
 
   // methods
   testCompile(api(Get[Json, Foo]))[GetElement[`Application/Json`.type, Foo] :: HNil]
@@ -52,6 +46,6 @@ object ApiDefinitionSpec {
 
   // whole api
   testCompile(
-    api(Get[Json, Foo], Root / "test" / Segment[Int]('foo), Queries add Query[String]('foo), Headers add Header[Double]('foo))
+    api(Get[Json, Foo], Root / "test" / Segment[Int]('foo), Queries add[String]('foo), Headers add[Double]('foo))
   )[GetElement[`Application/Json`.type, Foo] :: HeaderParam[fooW.T, Double] :: QueryParam[fooW.T, String] :: SegmentParam[fooW.T, Int] :: PathElement[testW.T] :: HNil]
 }

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -15,6 +15,8 @@ object ApiDslSpec {
 
   type Base = PathElement[testW.T] :: HNil
 
+  val a = Query[Int].apply(fooW)
+
   // empty path
   testCompile(:= :> Segment[Int](fooW))[SegmentParam[fooW.T, Int] :: HNil]
   testCompile(:= :> Query[Int](fooW))[QueryParam[fooW.T, Int] :: HNil]
@@ -58,16 +60,6 @@ object ApiDslSpec {
   test.illTyped("_baseH :> Query[Int](fooW)")
   testCompile(_baseH :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseH]
   testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseH]
-
-  // raw headers: add final
-  val _baseRH = base :> RawHeaders
-
-  type _BaseRH = RawHeaders.type :: Base
-
-  test.illTyped("_baseRH :> \"fail\"")
-  test.illTyped("_baseRH :> Segment[Int](fooW)")
-  test.illTyped("_baseRH :> Query[Int](fooW)")
-  testCompile(_baseRH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseRH]
 
   // request body: add put or post
   val _baseRB = base :> ReqBody[Plain, Foo]

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -59,6 +59,7 @@ object ApiDslSpec {
   test.illTyped("_baseH :> Segment[Int](fooW)")
   test.illTyped("_baseH :> Query[Int](fooW)")
   testCompile(_baseH :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseH]
+  testCompile(_baseH :> Fixed(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: FixedHeaderElement[fooW.T, testW.T] :: _BaseH]
   testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseH]
 
   // request body: add put or post

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -27,6 +27,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, String] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: FixedHeadersElement[(pathW.T, fooW.T) :: HNil] :: HNil, (FixedHeaders[(pathW.T, fooW.T) :: HNil] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: RawHeadersParam.type :: HNil, (RawHeadersInput :: HNil, RawHeadersField.T :: HNil, Map[String, String] :: HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -13,6 +13,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
 
   val pathW = Witness("test")
   val fooW  = Witness('foo)
+  val barW  = Witness('bar)
 
   type Json  = `Application/Json`.type
 
@@ -27,6 +28,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, String] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[
     GetElement[Json, Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -27,8 +27,6 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, String] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
-  testCompile[GetElement[Json, Foo] :: FixedHeadersElement[(pathW.T, fooW.T) :: HNil] :: HNil, (FixedHeaders[(pathW.T, fooW.T) :: HNil] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
-  testCompile[GetElement[Json, Foo] :: RawHeadersParam.type :: HNil, (RawHeadersInput :: HNil, RawHeadersField.T :: HNil, Map[String, String] :: HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[
     GetElement[Json, Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 


### PR DESCRIPTION
You are now able to add fixed (statically known key-value pairs) headers:

```Scala
val Api = := :> Fixed("Access-Control-Allow-Origin", "*") :> Get[Json, User]

// or

val Api = api(Get[Json, User], headers = Headers add("Access-Control-Allow-Origin", "*"))
```

Futhermore, I removed `RawHeaders`. This functionality is partially replaced with this PR and a follow-up change which will allow users to add headers to only the client or server side.