### PR TITLE
Add client/server-side specific headers

### DIFF
--- a/akka-http-server/src/main/scala/typedapi/server/akkahttp/package.scala
+++ b/akka-http-server/src/main/scala/typedapi/server/akkahttp/package.scala
@@ -93,7 +93,12 @@ package object akkahttp {
           request.uri.query().toMultiMap,
           request.headers.map(header => header.lowercaseName -> header.value)(collection.breakOut)
         )
-        execute(endpoints, eReq)
+
+        if (request.method.name == "OPTIONS") {
+          Future.successful(HttpResponse(headers = getHeaders(Map("Access-Control-Allow-Methods" -> checkMethods(endpoints, eReq, Nil).mkString(",")))))
+        }
+        else
+          execute(endpoints, eReq)
       }
     
       server.server.bind(server.host, server.port).to(Sink.foreach { connection =>

--- a/akka-http-server/src/main/scala/typedapi/server/akkahttp/package.scala
+++ b/akka-http-server/src/main/scala/typedapi/server/akkahttp/package.scala
@@ -95,7 +95,7 @@ package object akkahttp {
         )
 
         if (request.method.name == "OPTIONS") {
-          Future.successful(HttpResponse(headers = getHeaders(Map("Access-Control-Allow-Methods" -> checkMethods(endpoints, eReq, Nil).mkString(",")))))
+          Future.successful(HttpResponse(headers = getHeaders(optionsHeaders(endpoints, eReq))))
         }
         else
           execute(endpoints, eReq)

--- a/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
+++ b/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
@@ -120,9 +120,6 @@ trait RequestDataBuilderLowPrio {
   private def accept[MT <: MediaType](headers: Map[String, String], media: MT): Map[String, String] =
     Map(("Accept", media.value)) ++ headers
 
-  private def contentType[MT <: MediaType](headers: Map[String, String], media: MT): Map[String, String] =
-    Map(("Content-Type", media.value)) ++ headers
-
   implicit def getCompiler[MT <: MediaType, A](implicit media: Witness.Aux[MT]) = new RequestDataBuilder[HNil, HNil, HNil, GetCall, FieldType[MT, A]] {
     type Out = Data
 
@@ -143,12 +140,12 @@ trait RequestDataBuilderLowPrio {
     }
   }
 
-  implicit def putWithBodyCompiler[BMT <: MediaType, Bd, MT <: MediaType, A](implicit bodyMedia: Witness.Aux[BMT], media: Witness.Aux[MT]) = 
+  implicit def putWithBodyCompiler[BMT <: MediaType, Bd, MT <: MediaType, A](implicit media: Witness.Aux[MT]) = 
     new RequestDataBuilder[HNil, FieldType[BMT, BodyField.T] :: HNil, Bd :: HNil, PutWithBodyCall, FieldType[MT, A]] {
       type Out = DataWithBody[Bd]
 
       def apply(inputs: Bd :: HNil, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val out = uri.result() :: queries :: contentType(accept(headers, media.value), bodyMedia.value) :: inputs.head :: HNil
+        val out = uri.result() :: queries :: accept(headers, media.value) :: inputs.head :: HNil
 
         out
       }
@@ -164,12 +161,12 @@ trait RequestDataBuilderLowPrio {
     }
   }
 
-  implicit def postWithBodyCompiler[BMT <: MediaType, Bd, MT <: MediaType, A](implicit bodyMedia: Witness.Aux[BMT], media: Witness.Aux[MT]) = 
+  implicit def postWithBodyCompiler[BMT <: MediaType, Bd, MT <: MediaType, A](implicit media: Witness.Aux[MT]) = 
     new RequestDataBuilder[HNil, FieldType[BMT, BodyField.T] :: HNil, Bd :: HNil, PostWithBodyCall, FieldType[MT, A]] {
       type Out = DataWithBody[Bd]
 
       def apply(inputs: Bd :: HNil, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
-        val out = uri.result() :: queries :: contentType(accept(headers, media.value), bodyMedia.value) :: inputs.head :: HNil
+        val out = uri.result() :: queries :: accept(headers, media.value) :: inputs.head :: HNil
 
         out
       }

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -72,7 +72,7 @@ final class RequestDataBuilderSpec extends Specification {
 
       "request body" >> {
         val api0 = derive(:= :> ReqBody[Json, Int] :> Put[Json, ReqInputWithBody[Int]])
-        api0(0).run[Id](cm)(putB) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json"), ("Content-Type", "application/json")), 0)
+        api0(0).run[Id](cm)(putB) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json")), 0)
       }
 
       "path" >> {
@@ -91,7 +91,7 @@ final class RequestDataBuilderSpec extends Specification {
 
       find().run[Id](cm) === ReqInput("GET", "find" :: Nil, Map(), Map(("Accept", "application/json")))
       fetch("all").run[Id](cm) === ReqInput("GET", "fetch" :: "all" :: Nil, Map(), Map(("Accept", "application/json")))
-      store(0).run[Id](cm) === ReqInputWithBody("POST", "store" :: Nil, Map(), Map(("Accept", "application/json"), ("Content-Type", "application/json")), 0)
+      store(0).run[Id](cm) === ReqInputWithBody("POST", "store" :: Nil, Map(), Map(("Accept", "application/json")), 0)
     }
   }
 }

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -64,6 +64,10 @@ final class RequestDataBuilderSpec extends Specification {
         api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
         val api3 = derive(:= :> Fixed('i0, 'i1) :> Get[Json, ReqInput])
         api3().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
+        val api4 = derive(:= :> Client('i0, 'i1) :> Get[Json, ReqInput])
+        api4().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
+        val api5 = derive(:= :> Server('i0, 'i1) :> Get[Json, ReqInput])
+        api5().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
       }
 
       "request body" >> {

--- a/docs/example/shared/src/main/scala/Apis.scala
+++ b/docs/example/shared/src/main/scala/Apis.scala
@@ -5,9 +5,9 @@ object FromDsl {
 
   val MyApi = 
     // GET /fetch/user?name=<>
-    (:= :> "fetch" :> "user" :> Query[String]('name) :> Get[Json, User]) :|:
+    (:= :> "fetch" :> "user" :> Query[String]('name) :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     // POST /create/user
-    (:= :> "create" :> "user" :> ReqBody[Json, User] :> Post[Json, User])
+    (:= :> "create" :> "user" :> Server("Access-Control-Allow-Origin", "*") :> ReqBody[Json, User] :> Post[Json, User])
 }
 
 object FromDefinition {
@@ -19,12 +19,14 @@ object FromDefinition {
     api(
       method = Get[Json, User], 
       path = Root / "fetch" / "user", 
-      queries = Queries add Query[String]('name)
+      queries = Queries add[String]('name),
+      headers = Headers.server("Access-Control-Allow-Origin", "*")
     ) :|:
     // POST /create/user
     apiWithBody(
       method = Post[Json, User], 
       body = ReqBody[Json, User], 
-      path = Root / "create" / "user"
+      path = Root / "create" / "user",
+      headers = Headers.server("Access-Control-Allow-Origin", "*")
     )
 }

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -44,6 +44,8 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
     "headers" >> {
       h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
       h1().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      h2().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      h3().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -32,6 +32,8 @@ final class Http4sClientSupportSpec extends Specification {
     "headers" >> {
       h0(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
       h1().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      h2().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      h3().run[IO](cm).unsafeRunSync() === User("joe", 27)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -41,6 +41,18 @@ object TestServer {
 
       Ok(User("joe", 27))
 
+    case req @ GET -> Root / "header" / "client" =>
+      val headers = req.headers.toList
+      val value   = headers.find(_.name.value == "Hello").get.value
+
+      if (value != "*")
+        throw new IllegalArgumentException("unexpected header value " + value)
+
+      Ok(User("joe", 27))
+
+    case req @ GET -> Root / "header" / "server" =>
+      Ok(User("joe", 27)).map(resp => resp.copy(headers = resp.headers put Header("Hello", "*")))
+
     case GET -> Root => Ok(User("foo", 27))
     case PUT -> Root => Ok(User("foo", 27))
     case req @ PUT -> Root / "body" => Ok(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -10,6 +10,8 @@ package object tests {
     (:= :> "query" :> Query[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> Header[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> "fixed" :> Fixed("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "client" :> Client("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "server" :> Server("Hello", "*") :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:
     (:= :> Put[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -55,6 +55,17 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
           resp.headers.toList.find(_.name.toString == "Hello")
         }
       ).unsafeRunSync() === Some(Header("Hello", "*"))
+      client.fetch[Option[Header]](
+        Request[IO](
+          method = OPTIONS,
+          uri = Uri.fromString(s"http://localhost:$port/header/fixed").right.get,
+          headers = Headers(Header("Hello", "*"))
+        )
+      )(
+        resp => IO {
+          resp.headers.toList.find(_.name.toString == "Access-Control-Allow-Methods")
+        }
+      ).unsafeRunSync() === Some(Header("Access-Control-Allow-Methods", "GET"))
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -1,8 +1,7 @@
 package http.support.tests.server
 
 import http.support.tests.{User, UserCoding}
-import typedapi.dsl._
-import org.http4s.{Headers, Header, Request, Uri}
+import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.client.blaze._
 import org.http4s.client.dsl.io._
@@ -41,6 +40,21 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
         uri = Uri.fromString(s"http://localhost:$port/header/fixed").right.get,
         headers = Headers(Header("Hello", "*"))
       )).unsafeRunSync() === User("joe", 27)
+      client.expect[User](Request[IO](
+        method = GET,
+        uri = Uri.fromString(s"http://localhost:$port/header/client").right.get,
+        headers = Headers(Header("Hello", "*"))
+      )).unsafeRunSync() === User("joe", 27)
+      client.fetch[Option[Header]](
+        Request[IO](
+          method = GET,
+          uri = Uri.fromString(s"http://localhost:$port/header/server").right.get
+        )
+      )(
+        resp => IO {
+          resp.headers.toList.find(_.name.toString == "Hello")
+        }
+      ).unsafeRunSync() === Some(Header("Hello", "*"))
     }
 
     "methods" >> {

--- a/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
+++ b/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
@@ -92,7 +92,12 @@ package object http4s {
             request.uri.multiParams.map { case (key, value) => key -> value.toList },
             request.headers.toList.map(header => header.name.toString.toLowerCase -> header.value)(collection.breakOut)
           )
-          execute(endpoints, eReq)
+
+          if (request.method.name == "OPTIONS") {
+            IO.pure(Response(headers = Headers(Header("Access-Control-Allow-Methods", checkMethods(endpoints, eReq, Nil).mkString(",")))))
+          }
+          else
+            execute(endpoints, eReq)
       }
 
       server.server.bindHttp(server.port, server.host).mountService(service, "/").start

--- a/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
+++ b/http4s-server/src/main/scala/typedapi/server/htt4ps/package.scala
@@ -94,7 +94,7 @@ package object http4s {
           )
 
           if (request.method.name == "OPTIONS") {
-            IO.pure(Response(headers = Headers(Header("Access-Control-Allow-Methods", checkMethods(endpoints, eReq, Nil).mkString(",")))))
+            IO(Response(headers = Headers(getHeaders(optionsHeaders(endpoints, eReq)))))
           }
           else
             execute(endpoints, eReq)

--- a/server/src/main/scala/typedapi/server/Endpoint.scala
+++ b/server/src/main/scala/typedapi/server/Endpoint.scala
@@ -8,7 +8,7 @@ import shapeless.ops.function._
 import scala.language.higherKinds
 
 /** Container storing the extractor and function of an endpoint. */
-abstract class Endpoint[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], Out](val extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut]) {
+abstract class Endpoint[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], Out](val extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut], val headers: Map[String, String]) {
 
   def apply(in: VIn): F[Out]
 }
@@ -23,6 +23,7 @@ final class ExecutableDerivation[F[_]] {
 
   final class Derivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, Fn, Out]
     (extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+     headers: Map[String, String],
      fnToVIn: FnToProduct.Aux[Fn, VIn => F[Out]]) {
 
     /** Restricts type of parameter `fn` to a function defined by the given API:
@@ -34,7 +35,7 @@ final class ExecutableDerivation[F[_]] {
       * }}}
       */
     def from(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] =
-      new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor) {
+      new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor, headers) {
         private val fin = fnToVIn(fn)
 
         def apply(in: VIn): F[Out] = fin(in)
@@ -45,7 +46,8 @@ final class ExecutableDerivation[F[_]] {
     (apiList: ApiTypeCarrier[H])
     (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
               extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+              serverHeaders: ServerHeaderExtractor[El],
               inToFn: Lazy[FnFromProduct.Aux[VIn => F[Out], Fn]],
               fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]]): Derivation[El, KIn, VIn, M, ROut, Fn, Out] =
-    new Derivation[El, KIn, VIn, M, ROut, Fn, Out](extractor, fnToVIn.value)
+    new Derivation[El, KIn, VIn, M, ROut, Fn, Out](extractor, serverHeaders(Map.empty), fnToVIn.value)
 }

--- a/server/src/main/scala/typedapi/server/Endpoint.scala
+++ b/server/src/main/scala/typedapi/server/Endpoint.scala
@@ -8,7 +8,8 @@ import shapeless.ops.function._
 import scala.language.higherKinds
 
 /** Container storing the extractor and function of an endpoint. */
-abstract class Endpoint[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], Out](val extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut], val headers: Map[String, String]) {
+abstract class Endpoint[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], Out]
+    (val method: String, val extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut], val headers: Map[String, String]) {
 
   def apply(in: VIn): F[Out]
 }
@@ -23,6 +24,7 @@ final class ExecutableDerivation[F[_]] {
 
   final class Derivation[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, Fn, Out]
     (extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+     method: String,
      headers: Map[String, String],
      fnToVIn: FnToProduct.Aux[Fn, VIn => F[Out]]) {
 
@@ -35,7 +37,7 @@ final class ExecutableDerivation[F[_]] {
       * }}}
       */
     def from(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] =
-      new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor, headers) {
+      new Endpoint[El, KIn, VIn, M, ROut, F, Out](method, extractor, headers) {
         private val fin = fnToVIn(fn)
 
         def apply(in: VIn): F[Out] = fin(in)
@@ -46,8 +48,9 @@ final class ExecutableDerivation[F[_]] {
     (apiList: ApiTypeCarrier[H])
     (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
               extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+              methodShow: MethodToString[M],
               serverHeaders: ServerHeaderExtractor[El],
               inToFn: Lazy[FnFromProduct.Aux[VIn => F[Out], Fn]],
               fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]]): Derivation[El, KIn, VIn, M, ROut, Fn, Out] =
-    new Derivation[El, KIn, VIn, M, ROut, Fn, Out](extractor, serverHeaders(Map.empty), fnToVIn.value)
+    new Derivation[El, KIn, VIn, M, ROut, Fn, Out](extractor, methodShow.show, serverHeaders(Map.empty), fnToVIn.value)
 }

--- a/server/src/main/scala/typedapi/server/EndpointComposition.scala
+++ b/server/src/main/scala/typedapi/server/EndpointComposition.scala
@@ -48,6 +48,7 @@ trait PrecompileEndpointLowPrio {
 
   implicit def constructorsCase[F[_], Fn, El <: HList, KIn <: HList, VIn <: HList, MT <: MediaType, Out, M <: MethodType, ROut, T <: HList]
     (implicit extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+              methodShow: MethodToString[M],
               serverHeaders: ServerHeaderExtractor[El],
               vinToFn: FnFromProduct.Aux[VIn => F[Out], Fn],
               fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]],
@@ -57,7 +58,7 @@ trait PrecompileEndpointLowPrio {
       type Consts = EndpointConstructor[F, Fn, El, KIn, VIn, M, ROut, Out] :: next.Consts
 
       val constructor = new EndpointConstructor[F, Fn, El, KIn, VIn, M, ROut, Out] {
-        def apply(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] = new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor, serverHeaders(Map.empty)) {
+        def apply(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] = new Endpoint[El, KIn, VIn, M, ROut, F, Out](methodShow.show, extractor, serverHeaders(Map.empty)) {
           private val fin = fnToVIn.value(fn)
 
           def apply(in: VIn): F[Out] = fin(in)

--- a/server/src/main/scala/typedapi/server/EndpointComposition.scala
+++ b/server/src/main/scala/typedapi/server/EndpointComposition.scala
@@ -48,6 +48,7 @@ trait PrecompileEndpointLowPrio {
 
   implicit def constructorsCase[F[_], Fn, El <: HList, KIn <: HList, VIn <: HList, MT <: MediaType, Out, M <: MethodType, ROut, T <: HList]
     (implicit extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
+              serverHeaders: ServerHeaderExtractor[El],
               vinToFn: FnFromProduct.Aux[VIn => F[Out], Fn],
               fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]],
               next: PrecompileEndpoint[F, T]) =
@@ -56,7 +57,7 @@ trait PrecompileEndpointLowPrio {
       type Consts = EndpointConstructor[F, Fn, El, KIn, VIn, M, ROut, Out] :: next.Consts
 
       val constructor = new EndpointConstructor[F, Fn, El, KIn, VIn, M, ROut, Out] {
-        def apply(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] = new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor) {
+        def apply(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] = new Endpoint[El, KIn, VIn, M, ROut, F, Out](extractor, serverHeaders(Map.empty)) {
           private val fin = fnToVIn.value(fn)
 
           def apply(in: VIn): F[Out] = fin(in)

--- a/server/src/main/scala/typedapi/server/EndpointExecutor.scala
+++ b/server/src/main/scala/typedapi/server/EndpointExecutor.scala
@@ -26,7 +26,7 @@ sealed trait EndpointExecutor[El <: HList, KIn <: HList, VIn <: HList, M <: Meth
 object EndpointExecutor {
 
   type Aux[R0, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut, Out0] = EndpointExecutor[El, KIn, VIn, M, ROut, F, FOut] {
-    type R = R0
+    type R   = R0
     type Out = Out0
   }
 }

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -213,7 +213,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     type Out = REIn
 
     def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "GET") 
+      if (req.method == "GET" || req.method == "OPTIONS") 
         Right(inAgg.reverse)
       else 
         NotFoundE
@@ -224,7 +224,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     type Out = REIn
 
     def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "PUT") 
+      if (req.method == "PUT" || req.method == "OPTIONS") 
         Right(inAgg.reverse)
       else 
         NotFoundE
@@ -236,7 +236,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
       type Out = (BodyType[Bd], EIn)
 
       def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-        if (req.method == "PUT")
+        if (req.method == "PUT" || req.method == "OPTIONS")
           Right((BodyType[Bd], inAgg))
         else
           NotFoundE
@@ -247,7 +247,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     type Out = EIn
 
     def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "POST") 
+      if (req.method == "POST" || req.method == "OPTIONS") 
         Right(inAgg)
       else 
         NotFoundE
@@ -259,7 +259,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
       type Out = (BodyType[Bd], EIn)
 
       def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-        if (req.method == "POST")
+        if (req.method == "POST" || req.method == "OPTIONS")
           Right((BodyType[Bd], inAgg))
         else
           NotFoundE
@@ -270,7 +270,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     type Out = EIn
 
     def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-      if (req.method == "DELETE") 
+      if (req.method == "DELETE" || req.method == "OPTIONS")
         Right(inAgg)
       else 
         NotFoundE

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -181,6 +181,34 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
       }
     }
 
+  implicit def clientHeaderExtractor[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
+      (implicit kWit: Witness.Aux[K], kShow: WitnessToString[K], vWit: Witness.Aux[V], vShow: WitnessToString[V], next: RouteExtractor[El, KIn, VIn, M, EIn]) =
+    new RouteExtractor[shapeless.::[ClientHeader[K, V], El], KIn, VIn, M, EIn] {
+      type Out = next.Out
+
+      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
+        val key   = kShow.show(kWit.value)
+        val value = vShow.show(vWit.value)
+
+        req.headers.get(key.toLowerCase).fold(BadRequestE[Out](s"missing header '$key'")) { raw =>
+          if (raw != value)
+            BadRequestE[Out](s"header '$key' has unexpected value '${raw}' - expected '${value}'")
+          else
+            next(request, extractedHeaderKeys + key, inAgg)
+        }
+      }
+    }
+
+  implicit def ignoreServerHeaderExtractor[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
+      (implicit next: RouteExtractor[El, KIn, VIn, M, EIn]) =
+    new RouteExtractor[shapeless.::[ServerHeader[K, V], El], KIn, VIn, M, EIn] {
+      type Out = next.Out
+
+      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
+        next(request, extractedHeaderKeys, inAgg)
+      }
+    }
+
   implicit def getExtractor[EIn <: HList, REIn <: HList](implicit rev: Reverse.Aux[EIn, REIn]) = new RouteExtractor[HNil, HNil, HNil, GetCall, EIn] {
     type Out = REIn
 

--- a/server/src/main/scala/typedapi/server/Serve.scala
+++ b/server/src/main/scala/typedapi/server/Serve.scala
@@ -3,5 +3,6 @@ package typedapi.server
 /** Reduces an Endpoint and its EndpointExecutor to a simple Request => Response function. */
 trait Serve[Req, Resp] {
 
+  def exists(eReq: EndpointRequest): Option[String]
   def apply(req: Req, eReq: EndpointRequest): Either[ExtractionError, Resp]
 }

--- a/server/src/main/scala/typedapi/server/Serve.scala
+++ b/server/src/main/scala/typedapi/server/Serve.scala
@@ -3,6 +3,6 @@ package typedapi.server
 /** Reduces an Endpoint and its EndpointExecutor to a simple Request => Response function. */
 trait Serve[Req, Resp] {
 
-  def exists(eReq: EndpointRequest): Option[String]
+  def options(eReq: EndpointRequest): Option[(String, Map[String, String])]
   def apply(req: Req, eReq: EndpointRequest): Either[ExtractionError, Resp]
 }

--- a/server/src/main/scala/typedapi/server/ServerHeaderExtractor.scala
+++ b/server/src/main/scala/typedapi/server/ServerHeaderExtractor.scala
@@ -1,0 +1,39 @@
+package typedapi.server
+
+import typedapi.shared._
+import shapeless._
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("""Whoops, you should not be here. This seems to be a bug.
+
+elements: ${El}""")
+sealed trait ServerHeaderExtractor[El <: HList] {
+
+  def apply(agg: Map[String, String]): Map[String, String]
+}
+
+sealed trait ServerHeaderExtractorLowPrio {
+
+  implicit val serverHeaderReturnCase = new ServerHeaderExtractor[HNil] {
+    def apply(agg: Map[String, String]): Map[String, String] = agg
+  }
+
+  implicit def serverHeaderIgnoreCase[H, T <: HList](implicit next: ServerHeaderExtractor[T]) = new ServerHeaderExtractor[H :: T] {
+    def apply(agg: Map[String, String]): Map[String, String] = next(agg)
+  }
+}
+
+object ServerHeaderExtractor extends ServerHeaderExtractorLowPrio {
+
+  implicit def serverHeaderExtractCase[K, V, T <: HList]
+      (implicit kWit: Witness.Aux[K], kShow: WitnessToString[K], vWit: Witness.Aux[V], vShow: WitnessToString[V], next: ServerHeaderExtractor[T]) = 
+    new ServerHeaderExtractor[ServerHeader[K, V] :: T] {
+      def apply(agg: Map[String, String]): Map[String, String] = {
+        val key   = kShow.show(kWit.value)
+        val value = vShow.show(vWit.value)
+
+        next(agg + (key -> value))
+      }
+    }
+}

--- a/server/src/main/scala/typedapi/server/ServerManager.scala
+++ b/server/src/main/scala/typedapi/server/ServerManager.scala
@@ -1,5 +1,7 @@
 package typedapi.server
 
+import scala.annotation.tailrec
+
 final case class ServerManager[S](server: S, host: String, port: Int)
 
 object ServerManager {
@@ -11,6 +13,16 @@ object ServerManager {
 trait MountEndpoints[S, Req, Resp] {
 
   type Out
+
+  @tailrec
+  final def checkMethods(eps: List[Serve[Req, Resp]], eReq: EndpointRequest, agg: List[String]): List[String] = eps match {
+    case collection.immutable.::(endpoint, tail) => endpoint.exists(eReq) match {
+      case Some(method) => method :: agg
+      case _            => checkMethods(tail, eReq, agg)
+    }
+
+    case Nil => agg
+  }
 
   def apply(server: ServerManager[S], endpoints: List[Serve[Req, Resp]]): Out
 }

--- a/server/src/main/scala/typedapi/server/package.scala
+++ b/server/src/main/scala/typedapi/server/package.scala
@@ -13,11 +13,15 @@ package object server extends TypeLevelFoldLeftLowPrio
 
   def derive[F[_]]: ExecutableDerivation[F] = new ExecutableDerivation[F]
 
-
   def mount[S, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut, Req, Resp, Out]
       (server: ServerManager[S], endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut])
       (implicit executor: EndpointExecutor.Aux[Req, El, KIn, VIn, M, ROut, F, FOut, Resp], mounting: MountEndpoints.Aux[S, Req, Resp, Out]): Out =
     mounting(server, List(new Serve[executor.R, executor.Out] {
+      def exists(eReq: EndpointRequest): Option[String] = endpoint.extractor(eReq, Set.empty, HNil) match {
+        case Right(_) => Some(endpoint.method)
+        case _        => None
+      }
+
       def apply(req: executor.R, eReq: EndpointRequest): Either[ExtractionError, executor.Out] = executor(req, eReq, endpoint)
     }))
 
@@ -28,6 +32,11 @@ package object server extends TypeLevelFoldLeftLowPrio
     implicit def default[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut](implicit executor: EndpointExecutor[El, KIn, VIn, M, ROut, F, FOut]) = 
       at[Endpoint[El, KIn, VIn, M, ROut, F, FOut]] { endpoint =>
         new Serve[executor.R, executor.Out] {
+          def exists(eReq: EndpointRequest): Option[String] = endpoint.extractor(eReq, Set.empty, HNil) match {
+            case Right(_) => Some(endpoint.method)
+            case _        => None
+          }
+
           def apply(req: executor.R, eReq: EndpointRequest): Either[ExtractionError, executor.Out] = executor(req, eReq, endpoint)
         }
       }

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -15,9 +15,11 @@ final class ApiToEndpointLinkSpec extends Specification {
     val endpoint0 = derive[Option](Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
     endpoint0("john" :: 10 :: HNil) === Some(List(Foo("john")))
     endpoint0.headers == Map("foo" -> "bar")
+    endpoint0.method == "GET"
 
     val endpoint1 = derive[Option](Api).from((name, limit) => Option(List(Foo(name)).take(limit)))
     endpoint1("john" :: 10 :: HNil) === Some(List(Foo("john")))
     endpoint1.headers == Map("foo" -> "bar")
+    endpoint1.method == "GET"
   }
 }

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -10,12 +10,14 @@ final class ApiToEndpointLinkSpec extends Specification {
   case class Foo(name: String)
 
   "link api definitions to endpoint functions" >> { 
-    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Get[Json, List[Foo]]
+    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Client('hello, 'world) :> Server('foo, 'bar) :> Get[Json, List[Foo]]
 
-    val endpoint0 = derive[Option].apply(Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
+    val endpoint0 = derive[Option](Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
     endpoint0("john" :: 10 :: HNil) === Some(List(Foo("john")))
+    endpoint0.headers == Map("foo" -> "bar")
 
     val endpoint1 = derive[Option](Api).from((name, limit) => Option(List(Foo(name)).take(limit)))
     endpoint1("john" :: 10 :: HNil) === Some(List(Foo("john")))
+    endpoint1.headers == Map("foo" -> "bar")
   }
 }

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -89,10 +89,12 @@ final class RouteExtractorSpec extends Specification {
 
       ext0(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
       ext0(EndpointRequest("PUT", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("OPTIONS", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
 
       val ext1 = extract(:= :> ReqBody[Json, Foo] :> Post[Json, Foo])
 
       ext1(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
+      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
     }
 
     "methods" >> {
@@ -101,18 +103,22 @@ final class RouteExtractorSpec extends Specification {
       ext0(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
       ext0(EndpointRequest("WRONG", Nil, Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
       ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
 
       val ext1 = extract(:= :> Put[Json, Foo])
 
       ext1(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
 
       val ext2 = extract(:= :> Post[Json, Foo])
 
       ext2(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext2(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
 
       val ext3 = extract(:= :> Delete[Json, Foo])
 
       ext3(EndpointRequest("DELETE", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext3(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
     }
 
     "combinations" >> {

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -72,6 +72,16 @@ final class RouteExtractorSpec extends Specification {
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
+
+      val ext4 = extract(:= :> "foo" :> Client("Accept", "*") :> Get[Json, Foo])
+
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
+
+      val ext5 = extract(:= :> "foo" :> Server("Accept", "*") :> Get[Json, Foo])
+
+      ext5(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
     }
 
     "body type" >> {

--- a/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
+++ b/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
@@ -46,6 +46,11 @@ final class ServeAndMountSpec extends Specification {
   def toList[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, ROut, F[_], FOut](endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut])
                                                                                         (implicit executor: EndpointExecutor[El, KIn, VIn, M, ROut, F, FOut]): List[Serve[executor.R, executor.Out]] = 
     List(new Serve[executor.R, executor.Out] {
+      def exists(eReq: EndpointRequest): Option[String] = endpoint.extractor(eReq, Set.empty, HNil) match {
+        case Right(_) => Some(endpoint.method)
+        case _        => None
+      }
+
       def apply(req: executor.R, eReq: EndpointRequest): Either[ExtractionError, executor.Out] = executor(req, eReq, endpoint)
     })
 
@@ -62,6 +67,21 @@ final class ServeAndMountSpec extends Specification {
       val eReq = EndpointRequest("GET", req.uri, req.queries, req.headers)
 
       served.head(req, eReq) === Right(TestResponse("Some(List(Foo(joe)))"))
+    }
+
+    "check if route exists and return method" >> {
+      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Get[Json, List[Foo]]
+      val endpoint = derive[Option](Api).from((name, sortByAge) => Some(List(Foo(name))))
+      val served   = toList(endpoint)
+
+      val req0  = TestRequest(List("find", "user", "joe"), Map("sortByAge" -> List("1")), Map.empty)
+      val eReq0 = EndpointRequest("GET", req0.uri, req0.queries, req0.headers)
+
+      served.head.exists(eReq0) === Some("GET")
+
+      val eReq1 = EndpointRequest("POST", req0.uri, req0.queries, req0.headers)
+
+      served.head.exists(eReq1) === None
     }
 
     "serve single endpoint and with body" >> {

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -29,6 +29,8 @@ case object EmptyCons extends ApiListWithOps[HNil] {
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: HNil] = QueryCons()  
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: HNil] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: HNil] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: HNil] = ClientHeaderCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: HNil] = ServerHeaderCons()
 }
 
 /** Last set element is a path. */
@@ -39,6 +41,8 @@ final case class PathCons[H <: HList]() extends ApiListWithOps[H] {
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()  
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 /** Last set element is a segment. */
@@ -49,6 +53,8 @@ final case class SegmentCons[H <: HList]() extends ApiListWithOps[H] {
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 /** Last set element is a query parameter. */
@@ -57,6 +63,8 @@ final case class QueryCons[H <: HList]() extends ApiListWithOps[H]  {
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 /** Last set element is a header. */
@@ -64,10 +72,14 @@ sealed trait HeaderCons[H <: HList] extends ApiListWithOps[H] {
 
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 final case class InputHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class FixedHeaderCons[H <: HList]() extends HeaderCons[H]
+final case class ClientHeaderCons[H <: HList]() extends HeaderCons[H]
+final case class ServerHeaderCons[H <: HList]() extends HeaderCons[H]
 
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -10,6 +10,8 @@ package object dsl {
   def Query[V]   = new PairTypeFromWitnessKey[QueryParam, V]
   def Header[V]  = new PairTypeFromWitnessKey[HeaderParam, V]
   def Fixed      = new PairTypeFromWitnesses[FixedHeaderElement]
+  def Client     = new PairTypeFromWitnesses[ClientHeaderElement]
+  def Server     = new PairTypeFromWitnesses[ServerHeaderElement]
 
   type Json  = `Application/Json`.type
   type Plain = `Text/Plain`.type

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -2,7 +2,7 @@ package typedapi
 
 import typedapi.shared._
 
-package object dsl {
+package object dsl extends MethodToReqBodyLowPrio with MethodToStringLowPrio {
 
   def := = EmptyCons
 

--- a/shared/src/main/scala/typedapi/package.scala
+++ b/shared/src/main/scala/typedapi/package.scala
@@ -3,7 +3,7 @@ import typedapi.shared._
 import shapeless._
 import shapeless.ops.hlist.Prepend
 
-package object typedapi extends MethodToReqBodyLowPrio {
+package object typedapi extends MethodToReqBodyLowPrio with MethodToStringLowPrio {
 
   val Root       = PathListEmpty
   def Segment[V] = new PairTypeFromWitnessKey[SegmentParam, V]

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -19,7 +19,10 @@ sealed trait QueryParam[K, V] extends ApiElement
 /** Header which represents its key as singleton type and describes the value type. */
 sealed trait HeaderParam[K, V] extends ApiElement
 
+/** Header which represents its key and vlaue as singleton types. */
 sealed trait FixedHeaderElement[K, V] extends ApiElement
+sealed trait ClientHeaderElement[K, V] extends ApiElement
+sealed trait ServerHeaderElement[K, V] extends ApiElement
 
 /** Request body type description. */
 sealed trait ReqBodyElement[MT <: MediaType, A] extends ApiElement

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -58,6 +58,9 @@ trait MethodToReqBodyLowPrio {
 trait MediaType {
   def value: String
 }
+case object NoMediaType extends MediaType {
+  val value = "NO MEDIA TYPE"
+}
 case object `Application/Json` extends MediaType {
   val value = "application/json"
 }

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -33,4 +33,6 @@ final case class HeaderListBuilder[H <: HList]() {
 
   def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
   def add[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[FixedHeaderElement[K, V] :: H] = HeaderListBuilder()
+  def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
+  def server[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ServerHeaderElement[K, V] :: H] = HeaderListBuilder()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -21,6 +21,21 @@ sealed trait PostCall extends MethodType
 sealed trait PostWithBodyCall extends MethodType
 sealed trait DeleteCall extends MethodType
 
+trait MethodToString[M <: MethodType] {
+
+  def show: String
+}
+
+trait MethodToStringLowPrio {
+
+  implicit val getToStr      = new MethodToString[GetCall] { val show = "GET" }
+  implicit val putToStr      = new MethodToString[PutCall] { val show = "PUT" }
+  implicit val putBodyToStr  = new MethodToString[PutWithBodyCall] { val show = "PUT" }
+  implicit val postToStr     = new MethodToString[PostCall] { val show = "POST" }
+  implicit val postBodyToStr = new MethodToString[PostWithBodyCall] { val show = "POST" }
+  implicit val deleteToStr   = new MethodToString[DeleteCall] { val show = "DELETE" }
+}
+
 /** Separates uri, input description, method  and out type from `ApiList`. 
   * 
   *   Example:

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -10,6 +10,8 @@ sealed trait QueryInput extends ApiOp
 sealed trait HeaderInput extends ApiOp
 
 sealed trait FixedHeader[K, V] extends ApiOp
+sealed trait ClientHeader[K, V] extends ApiOp
+sealed trait ServerHeader[K, V] extends ApiOp
 
 trait MethodType extends ApiOp
 sealed trait GetCall extends MethodType
@@ -46,6 +48,12 @@ trait ApiTransformer {
 
   implicit def fixedHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[FixedHeaderElement[K, V], (El, KIn, VIn, M, Out), (FixedHeader[K, V] :: El, KIn, VIn, M, Out)]
+
+  implicit def clientHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ClientHeaderElement[K, V], (El, KIn, VIn, M, Out), (ClientHeader[K, V] :: El, KIn, VIn, M, Out)]
+
+  implicit def serverHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ServerHeaderElement[K, V], (El, KIn, VIn, M, Out), (ServerHeader[K, V] :: El, KIn, VIn, M, Out)]
 
   implicit def getTransformer[MT <: MediaType, A] = at[GetElement[MT, A], Unit, (HNil, HNil, HNil, GetCall, FieldType[MT, A])]
 

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -34,6 +34,8 @@ object ApiDefinitionSpec {
   testCompile(Headers add[Int](fooW))[HeaderParam[fooW.T, Int] :: HNil]
   testCompile(Headers add[Int](fooW) add[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
   testCompile(Headers add(fooW, testW))[FixedHeaderElement[fooW.T, testW.T] :: HNil]
+  testCompile(Headers client(fooW, testW))[ClientHeaderElement[fooW.T, testW.T] :: HNil]
+  testCompile(Headers server(fooW, testW))[ServerHeaderElement[fooW.T, testW.T] :: HNil]
 
   // methods
   testCompile(api(Get[Json, Foo]))[GetElement[`Application/Json`.type, Foo] :: HNil]

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -60,6 +60,8 @@ object ApiDslSpec {
   test.illTyped("_baseH :> Query[Int](fooW)")
   testCompile(_baseH :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseH]
   testCompile(_baseH :> Fixed(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: FixedHeaderElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Client(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: ClientHeaderElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Server(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: ServerHeaderElement[fooW.T, testW.T] :: _BaseH]
   testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/Json`.type, Foo] :: _BaseH]
 
   // request body: add put or post

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -29,6 +29,8 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ClientHeaderElement[fooW.T, barW.T] :: HNil, (ClientHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ServerHeaderElement[fooW.T, barW.T] :: HNil, (ServerHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[
     GetElement[Json, Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 


### PR DESCRIPTION
You are now able to define client/server-side specific headers:

```Scala
// dsl
:= :> Client("Foo", "Bar") :> Server("Bob", "Foo") :> Get[Json, User]

// function
api(Get[Json, User], headers = Headers client("Foo", "Bar") server("Bob", "Foo"))
```