### PR TITLE
Added Scalaj-Http support and extended header handling and client execution

### DIFF
--- a/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
+++ b/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
@@ -30,13 +30,18 @@ package object akkahttp {
   def getRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
                                                                   ec: ExecutionContext, 
                                                                   mat: Materializer) = new GetRequest[HttpExt, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.GET)
 
-      execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
+      execRequest(cm.client, request, bodyConsumerTimeout)
+    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap { response =>
         Unmarshal(response.entity).to[A]
       }
-    }
   }
 
 
@@ -48,13 +53,18 @@ package object akkahttp {
   def putRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
                                                                   ec: ExecutionContext, 
                                                                   mat: Materializer) = new PutRequest[HttpExt, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.PUT)
 
-      execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
+      execRequest(cm.client, request, bodyConsumerTimeout)
+    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap { response =>
         Unmarshal(response.entity).to[A]
       }
-    }
   }
 
   implicit def putRequestImpl[A](implicit bodyConsumerTimeout: FiniteDuration,
@@ -66,15 +76,20 @@ package object akkahttp {
                                                                           decoder: FromEntityUnmarshaller[A],
                                                                           ec: ExecutionContext, 
                                                                           mat: Materializer) = new PutWithBodyRequest[HttpExt, Future, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
         val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.PUT, entity = marshalledBody)
 
-        execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
-          Unmarshal(response.entity).to[A]
-        }
+        execRequest(cm.client, request, bodyConsumerTimeout)
       }
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, body, cm).flatMap { response =>
+        Unmarshal(response.entity).to[A]
+      }
   }
 
   implicit def putBodyRequestImpl[Bd, A](implicit bodyConsumerTimeout: FiniteDuration,
@@ -86,13 +101,18 @@ package object akkahttp {
   def postRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
                                                                    ec: ExecutionContext, 
                                                                    mat: Materializer) = new PostRequest[HttpExt, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.POST)
 
-      execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
+      execRequest(cm.client, request, bodyConsumerTimeout)
+    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap { response =>
         Unmarshal(response.entity).to[A]
       }
-    }
   }
 
   implicit def postRequestImpl[A](implicit bodyConsumerTimeout: FiniteDuration,
@@ -104,15 +124,20 @@ package object akkahttp {
                                                                            decoder: FromEntityUnmarshaller[A],
                                                                            ec: ExecutionContext, 
                                                                            mat: Materializer) = new PostWithBodyRequest[HttpExt, Future, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
         val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.POST, entity = marshalledBody)
 
-        execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
-          Unmarshal(response.entity).to[A]
-        }
+        execRequest(cm.client, request, bodyConsumerTimeout)
       }
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, body, cm).flatMap { response =>
+        Unmarshal(response.entity).to[A]
+      }
   }
 
   implicit def postBodyRequestImpl[Bd, A](implicit bodyConsumerTimeout: FiniteDuration,
@@ -124,13 +149,18 @@ package object akkahttp {
   def deleteRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
                                                                      ec: ExecutionContext, 
                                                                      mat: Materializer) = new DeleteRequest[HttpExt, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] = {
+    type Resp = HttpResponse
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.DELETE)
 
-      execRequest(cm.client, request, bodyConsumerTimeout).flatMap { response =>
+      execRequest(cm.client, request, bodyConsumerTimeout)
+    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap { response =>
         Unmarshal(response.entity).to[A]
       }
-    }
   }
 
   implicit def deleteRequestImpl[A](implicit bodyConsumerTimeout: FiniteDuration,

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val typedapi = project
     `akka-http-client`,
     `akka-http-server`,
     `js-client`,
+    `scalaj-http-client`,
     `http-support-tests`
   )
 
@@ -194,6 +195,16 @@ lazy val `js-client` = project
   )
   .dependsOn(`client-js`)
 
+lazy val `scalaj-http-client` = project
+  .in(file("scalaj-http-client"))
+  .settings(
+    commonSettings,
+    mavenSettings,
+    name := "typedapi-scalaj-http-client",
+    libraryDependencies ++= Dependencies.scalajHttpClient
+  )
+  .dependsOn(`client-jvm`)
+
 lazy val `http-support-tests` = project
   .in(file("http-support-tests"))
   .settings(
@@ -201,4 +212,4 @@ lazy val `http-support-tests` = project
     parallelExecution in Test := false,
     libraryDependencies ++= Dependencies.httpSupportTests
   )
-  .dependsOn(`http4s-client`, `http4s-server`, `akka-http-client`, `akka-http-server`)
+  .dependsOn(`http4s-client`, `http4s-server`, `akka-http-client`, `akka-http-server`, `scalaj-http-client`)

--- a/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
+++ b/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
@@ -17,6 +17,12 @@ final class ExecutableDerivation[El <: HList, KIn <: HList, VIn <: HList, M <: M
 
       req(data, cm)
     }
+
+    def raw[C](cm: ClientManager[C])(implicit req: ApiRequest[M, D, C, F, O]): F[req.Resp] = {
+      val data = builder(input, List.newBuilder, Map.empty, Map.empty)
+
+      req.raw(data, cm)
+    }
   }
 
   def run[F[_]]: Derivation[F] = new Derivation[F]

--- a/client/src/main/scala/typedapi/client/FilterServerElements.scala
+++ b/client/src/main/scala/typedapi/client/FilterServerElements.scala
@@ -1,0 +1,49 @@
+package typedapi.client
+
+import typedapi.shared.ServerHeaderElement
+import shapeless._
+
+//TODO replace with Typelevelfoldleft
+sealed trait FilterServerElements[H <: HList] {
+
+  type Out <: HList
+}
+
+sealed trait FilterServerElementsLowPrio {
+
+  implicit val filterServerResult = new FilterServerElements[HNil] {
+    type Out = HNil
+  }
+
+  implicit def filterServerKeep[El, T <: HList](implicit next: FilterServerElements[T]) = new FilterServerElements[El :: T] {
+    type Out = El :: next.Out
+  }
+}
+
+object FilterServerElements extends FilterServerElementsLowPrio {
+
+  type Aux[H <: HList, Out0 <: HList] = FilterServerElements[H] { type Out = Out0 }
+
+  implicit def filterServerEl[K, V, T <: HList](implicit next: FilterServerElements[T]) = new FilterServerElements[ServerHeaderElement[K, V] :: T] {
+    type Out = next.Out
+  }
+}
+
+sealed trait FilterServerElementsList[H <: HList] {
+
+  type Out <: HList
+}
+
+object FilterServerElementsList {
+
+  type Aux[H <: HList, Out0 <: HList] = FilterServerElementsList[H] { type Out = Out0 }
+
+  implicit val filterServerListResult = new FilterServerElementsList[HNil] {
+    type Out = HNil
+  }
+
+  implicit def filterServerListStep[Api <: HList, T <: HList](implicit filtered: FilterServerElements[Api], next: FilterServerElementsList[T]) = 
+    new FilterServerElementsList[Api :: T] {
+      type Out = filtered.Out :: next.Out
+    }
+}

--- a/client/src/main/scala/typedapi/client/package.scala
+++ b/client/src/main/scala/typedapi/client/package.scala
@@ -13,17 +13,20 @@ package object client extends TypeLevelFoldLeftLowPrio
 
   def deriveUriString(cm: ClientManager[_], uri: List[String]): String = cm.base + "/" + uri.mkString("/")
 
-  def derive[H <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, MT <: MediaType, Out, D <: HList]
+  def derive[H <: HList, FH <: HList, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, MT <: MediaType, Out, D <: HList]
     (apiList: ApiTypeCarrier[H])
-    (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
+    (implicit filter: FilterServerElements.Aux[H, FH],
+              folder: Lazy[TypeLevelFoldLeft.Aux[FH, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
               builder: RequestDataBuilder.Aux[El, KIn, VIn, M, FieldType[MT, Out], D],
               inToFn: FnFromProduct[VIn => ExecutableDerivation[El, KIn, VIn, M, MT, Out, D]]): inToFn.Out =
     inToFn.apply(input => new ExecutableDerivation[El, KIn, VIn, M, MT, Out, D](builder, input))
 
-  def deriveAll[H <: HList, In <: HList, Fold <: HList, B <: HList, Ex <: HList](apiLists: CompositionCons[H])
-                                                                                (implicit folders: TypeLevelFoldLeftList.Aux[H, Fold],
-                                                                                          builderList: RequestDataBuilderList.Aux[Fold, B],
-                                                                                          executables: ExecutablesFromHList.Aux[B, Ex],
-                                                                                          tupler: Tupler[Ex]): tupler.Out =
+  def deriveAll[H <: HList, FH <: HList, In <: HList, Fold <: HList, B <: HList, Ex <: HList]
+    (apiLists: CompositionCons[H])
+    (implicit filter: FilterServerElementsList.Aux[H, FH],
+              folders: TypeLevelFoldLeftList.Aux[FH, Fold],
+              builderList: RequestDataBuilderList.Aux[Fold, B],
+              executables: ExecutablesFromHList.Aux[B, Ex],
+              tupler: Tupler[Ex]): tupler.Out =
     executables(builderList.builders).tupled
 }

--- a/client/src/main/scala/typedapi/client/test/package.scala
+++ b/client/src/main/scala/typedapi/client/test/package.scala
@@ -8,27 +8,45 @@ package object test {
 
   val clientManager: TestClientM = ClientManager((), "", 0)
 
-  def testGet[F[_], A](f: ReqInput => F[A]) = new GetRequest[Unit, F, A] {
+  def testGet[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new GetRequest[Unit, F, A] {
+    type Resp = ReqInput
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("GET", uri, queries, headers))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("GET", uri, queries, headers))
   }
 
-  def testPut[F[_], A](f: ReqInput => F[A]) = new PutRequest[Unit, F, A] {
+  def testPut[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new PutRequest[Unit, F, A] {
+    type Resp = ReqInput
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("PUT", uri, queries, headers))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("PUT", uri, queries, headers))
   }
 
-  def testPutWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A]) = new PutWithBodyRequest[Unit, F, Bd, A] {
+  def testPutWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A])(pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = new PutWithBodyRequest[Unit, F, Bd, A] {
+    type Resp = ReqInputWithBody[Bd]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = pure(ReqInputWithBody("PUT", uri, queries, headers, body))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = f(ReqInputWithBody("PUT", uri, queries, headers, body))
   }
 
-  def testPost[F[_], A](f: ReqInput => F[A]) = new PostRequest[Unit, F, A] {
+  def testPost[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new PostRequest[Unit, F, A] {
+    type Resp = ReqInput
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("POST", uri, queries, headers))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("POST", uri, queries, headers))
   }
 
-  def testPostWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A]) = new PostWithBodyRequest[Unit, F, Bd, A] {
+  def testPostWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A])(pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = new PostWithBodyRequest[Unit, F, Bd, A] {
+    type Resp = ReqInputWithBody[Bd]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = pure(ReqInputWithBody("POST", uri, queries, headers, body))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = f(ReqInputWithBody("POST", uri, queries, headers, body))
   }
 
-  def testDelete[F[_], A](f: ReqInput => F[A]) = new DeleteRequest[Unit, F, A] {
+  def testDelete[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new DeleteRequest[Unit, F, A] {
+    type Resp = ReqInput
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("DELETE", uri, queries, headers))
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("DELETE", uri, queries, headers))
   }
 }

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -12,12 +12,12 @@ final class RequestDataBuilderSpec extends Specification {
 
   type Result = (String, List[String], Map[String, String], Map[String, String], Option[Foo])
 
-  implicit val get       = testGet[Id, ReqInput](identity)
-  implicit val put       = testPut[Id, ReqInput](identity)
-  implicit def putB[Bd]  = testPutWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)
-  implicit val post      = testPost[Id, ReqInput](identity)
-  implicit def postB[Bd] = testPostWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)
-  implicit val delete    = testDelete[Id, ReqInput](identity)
+  implicit val get       = testGet[Id, ReqInput](identity)(identity)
+  implicit val put       = testPut[Id, ReqInput](identity)(identity)
+  implicit def putB[Bd]  = testPutWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)(identity)
+  implicit val post      = testPost[Id, ReqInput](identity)(identity)
+  implicit def postB[Bd] = testPostWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)(identity)
+  implicit val delete    = testDelete[Id, ReqInput](identity)(identity)
 
   "executes compiled api" >> {
     val cm = clientManager

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -64,10 +64,15 @@ final class RequestDataBuilderSpec extends Specification {
         api2(None).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
         val api3 = derive(:= :> Header('i0, 'i1) :> Get[Json, ReqInput])
         api3().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
-        val api4 = derive(:= :> Client('i0, 'i1) :> Get[Json, ReqInput])
-        api4().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
-        val api5 = derive(:= :> Server('i0, 'i1) :> Get[Json, ReqInput])
-        api5().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json"))
+        val api4 = derive(:= :> Client.Header[Int]('i0) :> Get[Json, ReqInput])
+        api4(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
+        val api5 = derive(:= :> Client.Header('i0, 'i1) :> Get[Json, ReqInput])
+        api5().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
+      }
+
+      "ignore server elements" >> {
+        val api0 = derive(:= :> Server.Header('s1, 's2) :> Client.Header[Int]('i0) :> Get[Json, ReqInput])
+        api0(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
       }
 
       "request body" >> {
@@ -83,7 +88,7 @@ final class RequestDataBuilderSpec extends Specification {
 
     "composition" >> {
       val api = 
-        (:= :> "find" :> Get[Json, ReqInput]) :|:
+        (:= :> "find" :> Server.Header("Test", "ignore") :> Get[Json, ReqInput]) :|:
         (:= :> "fetch" :> Segment[String]('type) :> Get[Json, ReqInput]) :|:
         (:= :> "store" :> ReqBody[Json, Int] :> Post[Json, ReqInputWithBody[Int]])
 

--- a/docs/example/client-js/src/main/scala/Client.scala
+++ b/docs/example/client-js/src/main/scala/Client.scala
@@ -17,11 +17,11 @@ object Client {
 
   final case class DecodeException(msg: String) extends Exception
 
-  implicit val decoder = typedapi.client.js.Decoder[Future, User](json => decode[User](json).fold(
+  implicit val decoder = typedapi.util.Decoder[Future, User](json => decode[User](json).fold(
     error => Future.successful(Left(DecodeException(error.toString()))), 
     user  => Future.successful(Right(user))
   ))
-  implicit val encoder = typedapi.client.js.Encoder[Future, User](user => Future.successful(user.asJson.noSpaces))
+  implicit val encoder = typedapi.util.Encoder[Future, User](user => Future.successful(user.asJson.noSpaces))
 
   val (get, put, post, delete, path, putBody, segment, search, header, fixed, client) = deriveAll(FromDsl.MyApi)
 

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -44,8 +44,9 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
     "headers" >> {
       h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
       h1().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
-      h2().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      h2("jim").run[Future](cm) must beEqualTo(User("jim", 27)).awaitFor(timeout)
       h3().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      h4().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -32,8 +32,9 @@ final class Http4sClientSupportSpec extends Specification {
     "headers" >> {
       h0(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
       h1().run[IO](cm).unsafeRunSync() === User("joe", 27)
-      h2().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      h2("jim").run[IO](cm).unsafeRunSync === User("jim", 27)
       h3().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      h4().run[IO](cm).unsafeRunSync() === User("joe", 27)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -1,0 +1,61 @@
+package http.support.tests.client
+
+import http.support.tests.{UserCoding, User, Api}
+import typedapi.client._
+import typedapi.client.scalajhttp._
+import scalaj.http.Http
+import io.circe.parser._
+import io.circe.syntax._
+import org.specs2.mutable.Specification
+
+final class ScalajHttpClientSupportSpec extends Specification {
+
+  import UserCoding._
+
+  sequential
+
+  case class DecodeException(msg: String) extends Exception
+
+  implicit val decoder = typedapi.util.Decoder[Id, User](json => decode[User](json).fold(
+    error => Left(DecodeException(error.toString())),
+    user  => Right(user)
+  ))
+  implicit val encoder = typedapi.util.Encoder[Id, User](user => user.asJson.noSpaces)
+
+  val cm = ClientManager(Http, "http://localhost", 9001)
+
+  val server = TestServer.start()
+
+  "http4s client support" >> {
+    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+
+    "paths and segments" >> {
+      p().run[Blocking](cm) === Right(User("foo", 27))
+      s("jim").run[Blocking](cm) === Right(User("jim", 27))
+    }
+    
+    "queries" >> {
+      q(42).run[Blocking](cm) === Right(User("foo", 42))
+    }
+    
+    "headers" >> {
+      h0(42).run[Blocking](cm) === Right(User("foo", 42))
+      h1().run[Blocking](cm) === Right(User("joe", 27))
+      h2().run[Blocking](cm) === Right(User("joe", 27))
+      h3().run[Blocking](cm) === Right(User("joe", 27))
+    }
+
+    "methods" >> {
+      m0().run[Blocking](cm) === Right(User("foo", 27))
+      m1().run[Blocking](cm) === Right(User("foo", 27))
+      m2(User("jim", 42)).run[Blocking](cm) === Right(User("jim", 42))
+      m3().run[Blocking](cm) === Right(User("foo", 27))
+      m4(User("jim", 42)).run[Blocking](cm) === Right(User("jim", 42))
+      m5(List("because")).run[Blocking](cm) === Right(User("foo", 27))
+    }
+
+    step {
+      server.shutdown.unsafeRunSync()
+    }
+  }
+}

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -54,6 +54,10 @@ final class ScalajHttpClientSupportSpec extends Specification {
       m5(List("because")).run[Blocking](cm) === Right(User("foo", 27))
     }
 
+    "raw" >> {
+      m0().run[Blocking].raw(cm).right.map(_.body) === Right("""{"name":"foo","age":27}""")
+    }
+
     step {
       server.shutdown.unsafeRunSync()
     }

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -27,7 +27,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, h2, h3, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Blocking](cm) === Right(User("foo", 27))
@@ -41,8 +41,9 @@ final class ScalajHttpClientSupportSpec extends Specification {
     "headers" >> {
       h0(42).run[Blocking](cm) === Right(User("foo", 42))
       h1().run[Blocking](cm) === Right(User("joe", 27))
-      h2().run[Blocking](cm) === Right(User("joe", 27))
+      h2("jim").run[Blocking](cm) === Right(User("jim", 27))
       h3().run[Blocking](cm) === Right(User("joe", 27))
+      h4().run[Blocking](cm) === Right(User("joe", 27))
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -50,6 +50,12 @@ object TestServer {
 
       Ok(User("joe", 27))
 
+    case req @ GET -> Root / "header" / "input" / "client" =>
+      val headers = req.headers.toList
+      val value   = headers.find(_.name.value == "Hello").get.value
+
+      Ok(User(value, 27))
+
     case req @ GET -> Root / "header" / "server" =>
       Ok(User("joe", 27)).map(resp => resp.copy(headers = resp.headers put Header("Hello", "*")))
 

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -10,8 +10,9 @@ package object tests {
     (:= :> "query" :> Query[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> Header[Int]('age) :> Get[Json, User]) :|:
     (:= :> "header" :> "fixed" :> Header("Hello", "*") :> Get[Json, User]) :|:
-    (:= :> "header" :> "client" :> Client("Hello", "*") :> Get[Json, User]) :|:
-    (:= :> "header" :> "server" :> Server("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "input" :> "client" :> Client.Header[String]("Hello") :> Get[Json, User]) :|:
+    (:= :> "header" :> "client" :> Client.Header("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "server" :> Server.Header("Hello", "*") :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:
     (:= :> Put[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -42,8 +42,11 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
       )).unsafeRunSync() === User("joe", 27)
       client.expect[User](Request[IO](
         method = GET,
-        uri = Uri.fromString(s"http://localhost:$port/header/client").right.get,
-        headers = Headers(Header("Hello", "*"))
+        uri = Uri.fromString(s"http://localhost:$port/header/client").right.get
+      )).unsafeRunSync() === User("joe", 27)
+      client.expect[User](Request[IO](
+        method = GET,
+        uri = Uri.fromString(s"http://localhost:$port/header/input/client").right.get
       )).unsafeRunSync() === User("joe", 27)
       client.fetch[Option[Header]](
         Request[IO](

--- a/http4s-client/src/main/scala/typedapi/client/http4s/package.scala
+++ b/http4s-client/src/main/scala/typedapi/client/http4s/package.scala
@@ -1,14 +1,16 @@
 package typedapi.client
 
-import cats.MonadError
+import cats.{MonadError, Applicative}
 import org.http4s._
 import org.http4s.client._
+import org.http4s.Status.Successful
+import org.http4s.headers.{Accept, MediaRangeAndQValue}
 
 import scala.language.higherKinds
 
 package object http4s {
 
-  private implicit class TypedApiRequestOps[F[_]](req: Request[F]) {
+  private implicit class Http4sRequestOps[F[_]](req: Request[F]) {
 
     def withQuery(queries: Map[String, List[String]]): Request[F] = {
       if (queries.nonEmpty) {
@@ -28,71 +30,122 @@ package object http4s {
       }
       else req
     }
+
+    def run[A](cm: ClientManager[Client[F]])(implicit d: EntityDecoder[F, A], F: Applicative[F]): F[Response[F]] = {
+      val r = 
+        if (d.consumes.nonEmpty) {
+          val m = d.consumes.toList
+          req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+        } 
+        else req
+
+      cm.client.fetch(r)(resp => F.pure(resp))
+    }
+  }
+
+  private implicit class Http4sResponseOps[F[_]](resp: Response[F]) {
+
+    def decode[A](implicit d: EntityDecoder[F, A], F: MonadError[F, Throwable]): F[A] = resp match {
+      case Successful(_resp) =>
+        d.decode(_resp, strict = false).fold(throw _, identity)
+      case failedResponse =>
+        F.raiseError(UnexpectedStatus(failedResponse.status))
+    }
   }
 
   implicit def getRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new GetRequest[Client[F], F, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] = {
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.GET, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      cm.client.expect[A](request)
+      request.run[A](cm)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
   implicit def putRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PutRequest[Client[F], F, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] = {
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.PUT, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      cm.client.expect[A](request)
+      request.run[A](cm)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
   implicit def putBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
                                                     decoder: EntityDecoder[F, A], 
                                                     F: MonadError[F, Throwable]) = new PutWithBodyRequest[Client[F], F, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] = {
-      val request = Request[F](Method.PUT, Uri.unsafeFromString(deriveUriString(cm, uri)))
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
+      val requestF = Request[F](Method.PUT, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
         .withBody(body)
 
-      cm.client.expect[A](request)
+      F.flatMap(requestF)(_.run[A](cm))
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, body, cm))(_.decode[A])
   }
 
   implicit def postRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PostRequest[Client[F], F, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] = {
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.POST, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      cm.client.expect[A](request)
+      request.run[A](cm)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
   implicit def postBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
                                                      decoder: EntityDecoder[F, A], 
                                                      F: MonadError[F, Throwable]) = new PostWithBodyRequest[Client[F], F, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] = {
-      val request = Request[F](Method.POST, Uri.unsafeFromString(deriveUriString(cm, uri)))
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
+      val requestF = Request[F](Method.POST, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
         .withBody(body)
 
-      cm.client.expect[A](request)
+      F.flatMap(requestF)(_.run[A](cm))
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, body, cm))(_.decode[A])
   }
 
   implicit def deleteRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new DeleteRequest[Client[F], F, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] = {
+    type Resp = Response[F]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.DELETE, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      cm.client.expect[A](request)
+      request.run[A](cm)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
+      F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 }

--- a/js-client/src/main/scala/typedapi/client/js/package.scala
+++ b/js-client/src/main/scala/typedapi/client/js/package.scala
@@ -1,6 +1,7 @@
 package typedapi.client
 
 import typedapi.util._
+import org.scalajs.dom.XMLHttpRequest
 import org.scalajs.dom.ext.Ajax
 
 import scala.concurrent.{Future, ExecutionContext}
@@ -21,29 +22,37 @@ package object js {
   }
 
   implicit def getRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new GetRequest[Ajax.type, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .get(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
-        .flatMap(response => flatten(decoder(response.responseText)))
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
   implicit def putRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PutRequest[Ajax.type, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .put(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
-        .flatMap(response => flatten(decoder(response.responseText)))
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
   implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PutWithBodyRequest[Ajax.type, Future, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
       encoder(body).flatMap { encoded => 
         cm.client
           .put(
@@ -51,24 +60,30 @@ package object js {
             headers = headers,
             data    = encoded
           )
-          .flatMap(response => flatten(decoder(response.responseText)))
       }
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, body, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
   implicit def postRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PostRequest[Ajax.type, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .post(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
-        .flatMap(response => flatten(decoder(response.responseText)))
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
   implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PostWithBodyRequest[Ajax.type, Future, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
       encoder(body).flatMap { encoded =>
         cm.client
           .post(
@@ -76,19 +91,23 @@ package object js {
             headers = headers,
             data    = encoded
           )
-          .flatMap(response => flatten(decoder(response.responseText)))
       }
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, body, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
   implicit def deleteRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new DeleteRequest[Ajax.type, Future, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] = {
+    type Resp = XMLHttpRequest
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .delete(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
-        .flatMap(response => flatten(decoder(response.responseText)))
-    }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
+      raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 }

--- a/js-client/src/main/scala/typedapi/client/js/package.scala
+++ b/js-client/src/main/scala/typedapi/client/js/package.scala
@@ -1,5 +1,6 @@
 package typedapi.client
 
+import typedapi.util._
 import org.scalajs.dom.ext.Ajax
 
 import scala.concurrent.{Future, ExecutionContext}

--- a/project/build.scala
+++ b/project/build.scala
@@ -41,6 +41,12 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-core" % akkaHttpV % Provided
   )
 
+  private val scalajHttpV = "2.4.1"
+
+  val scalajHttpClient = Seq(
+    "org.scalaj" %% "scalaj-http" % scalajHttpV % Provided
+  )
+
   private val circeV = "0.9.1"
 
   val httpSupportTests = Seq(
@@ -51,6 +57,7 @@ object Dependencies {
     "org.http4s" %% "http4s-dsl" % http4sV          % Test,
     "org.http4s" %% "http4s-circe" % http4sV        % Test,
     "com.typesafe.akka" %% "akka-http" % akkaHttpV  % Test,
+    "org.scalaj" %% "scalaj-http" % scalajHttpV     % Test,
 
     "io.circe"   %% "circe-core" % circeV               % Test,
     "io.circe"   %% "circe-parser" % circeV             % Test,

--- a/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
+++ b/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
@@ -12,50 +12,80 @@ package object scalajhttp {
     queries.map { case (key, values) => key -> values.mkString(",") }(collection.breakOut)
 
   implicit def getRequest[A](implicit decoder: Decoder[Id, A]) = new GetRequest[Http.type, Blocking, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("GET")
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
   }
 
   implicit def putRequest[A](implicit decoder: Decoder[Id, A]) = new PutRequest[Http.type, Blocking, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+    
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("PUT")
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
   }
 
   implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PutWithBodyRequest[Http.type, Blocking, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+    
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).put(encoder(body))
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, body, cm).right.flatMap(resp => decoder(resp.body))
   }
 
   implicit def postRequest[A](implicit decoder: Decoder[Id, A]) = new PostRequest[Http.type, Blocking, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+    
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("POST")
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
   }
 
   implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PostWithBodyRequest[Http.type, Blocking, Bd, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+    
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).postData(encoder(body))
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, body, cm).right.flatMap(resp => decoder(resp.body))
   }
 
   implicit def deleteRequest[A](implicit decoder: Decoder[Id, A]) = new DeleteRequest[Http.type, Blocking, A] {
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+    type Resp = HttpResponse[String]
+
+    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("DELETE")
 
-      decoder(req.asString.body)
+      Right(req.asString)
     }
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
+      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
   }
 }

--- a/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
+++ b/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
@@ -1,0 +1,61 @@
+package typedapi.client
+
+import typedapi.util._
+import scalaj.http._
+
+package object scalajhttp {
+
+  type Id[A]       = A
+  type Blocking[A] = Either[Exception, A]
+
+  private def reduceQueries(queries: Map[String, List[String]]): Map[String, String] = 
+    queries.map { case (key, values) => key -> values.mkString(",") }(collection.breakOut)
+
+  implicit def getRequest[A](implicit decoder: Decoder[Id, A]) = new GetRequest[Http.type, Blocking, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("GET")
+
+      decoder(req.asString.body)
+    }
+  }
+
+  implicit def putRequest[A](implicit decoder: Decoder[Id, A]) = new PutRequest[Http.type, Blocking, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("PUT")
+
+      decoder(req.asString.body)
+    }
+  }
+
+  implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PutWithBodyRequest[Http.type, Blocking, Bd, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).put(encoder(body))
+
+      decoder(req.asString.body)
+    }
+  }
+
+  implicit def postRequest[A](implicit decoder: Decoder[Id, A]) = new PostRequest[Http.type, Blocking, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("POST")
+
+      decoder(req.asString.body)
+    }
+  }
+
+  implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PostWithBodyRequest[Http.type, Blocking, Bd, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).postData(encoder(body))
+
+      decoder(req.asString.body)
+    }
+  }
+
+  implicit def deleteRequest[A](implicit decoder: Decoder[Id, A]) = new DeleteRequest[Http.type, Blocking, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("DELETE")
+
+      decoder(req.asString.body)
+    }
+  }
+}

--- a/server/src/main/scala/typedapi/server/Endpoint.scala
+++ b/server/src/main/scala/typedapi/server/Endpoint.scala
@@ -44,9 +44,10 @@ final class ExecutableDerivation[F[_]] {
       }
   }
 
-  def apply[H <: HList, El <: HList, KIn <: HList, VIn <: HList, ROut, Fn, M <: MethodType, MT <: MediaType, Out]
+  def apply[H <: HList, FH <: HList, El <: HList, KIn <: HList, VIn <: HList, ROut, Fn, M <: MethodType, MT <: MediaType, Out]
     (apiList: ApiTypeCarrier[H])
-    (implicit folder: Lazy[TypeLevelFoldLeft.Aux[H, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
+    (implicit filter: FilterClientElements.Aux[H, FH],
+              folder: Lazy[TypeLevelFoldLeft.Aux[FH, Unit, (El, KIn, VIn, M, FieldType[MT, Out])]],
               extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
               methodShow: MethodToString[M],
               serverHeaders: ServerHeaderExtractor[El],

--- a/server/src/main/scala/typedapi/server/EndpointComposition.scala
+++ b/server/src/main/scala/typedapi/server/EndpointComposition.scala
@@ -126,8 +126,9 @@ final class ExecutableCompositionDerivation[F[_]] {
     val from: Drv = derived.apply(fns => merge(pre.constructors, fns))
   }
 
-  def apply[H <: HList, Fold <: HList, Fns <: HList, FnsTup, Consts <: HList, Out <: HList, Drv](apiLists: CompositionCons[H])
-                                      (implicit folder: TypeLevelFoldLeftList.Aux[H, Fold],
+  def apply[H <: HList, FH <: HList, Fold <: HList, Fns <: HList, FnsTup, Consts <: HList, Out <: HList, Drv](apiLists: CompositionCons[H])
+                                      (implicit filter: FilterClientElementsList.Aux[H, FH],
+                                                folder: TypeLevelFoldLeftList.Aux[FH, Fold],
                                                 pre: PrecompileEndpoint.Aux[F, Fold, Fns, Consts],
                                                 merge: MergeToEndpoint.Aux[F, Consts, Fns, Out],
                                                 derived: FnFromProduct.Aux[Fns => Out, Drv]): Derivation[Fold, Fns, Consts, Out, Drv] =

--- a/server/src/main/scala/typedapi/server/FilterClientElements.scala
+++ b/server/src/main/scala/typedapi/server/FilterClientElements.scala
@@ -1,0 +1,52 @@
+package typedapi.server
+
+import typedapi.shared.{ClientHeaderElement, ClientHeaderParam}
+import shapeless._
+
+sealed trait FilterClientElements[H <: HList] {
+
+  type Out <: HList
+}
+
+sealed trait FilterClientElementsLowPrio {
+
+  implicit val filterClientResult = new FilterClientElements[HNil] {
+    type Out = HNil
+  }
+
+  implicit def filterClientKeep[El, T <: HList](implicit next: FilterClientElements[T]) = new FilterClientElements[El :: T] {
+    type Out = El :: next.Out
+  }
+}
+
+object FilterClientElements extends FilterClientElementsLowPrio {
+
+  type Aux[H <: HList, Out0 <: HList] = FilterClientElements[H] { type Out = Out0 }
+
+  implicit def filterClientEl[K, V, T <: HList](implicit next: FilterClientElements[T]) = new FilterClientElements[ClientHeaderElement[K, V] :: T] {
+    type Out = next.Out
+  }
+
+  implicit def filterClientParam[K, V, T <: HList](implicit next: FilterClientElements[T]) = new FilterClientElements[ClientHeaderParam[K, V] :: T] {
+    type Out = next.Out
+  }
+}
+
+sealed trait FilterClientElementsList[H <: HList] {
+
+  type Out <: HList
+}
+
+object FilterClientElementsList {
+
+  type Aux[H <: HList, Out0 <: HList] = FilterClientElementsList[H] { type Out = Out0 }
+
+  implicit val filterClientListResult = new FilterClientElementsList[HNil] {
+    type Out = HNil
+  }
+
+  implicit def filterClientListStep[Api <: HList, T <: HList](implicit filtered: FilterClientElements[Api], next: FilterClientElementsList[T]) = 
+    new FilterClientElementsList[Api :: T] {
+      type Out = filtered.Out :: next.Out
+    }
+}

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -181,25 +181,7 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
       }
     }
 
-  implicit def clientHeaderExtractor[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
-      (implicit kWit: Witness.Aux[K], kShow: WitnessToString[K], vWit: Witness.Aux[V], vShow: WitnessToString[V], next: RouteExtractor[El, KIn, VIn, M, EIn]) =
-    new RouteExtractor[shapeless.::[ClientHeader[K, V], El], KIn, VIn, M, EIn] {
-      type Out = next.Out
-
-      def apply(request: EndpointRequest, extractedHeaderKeys: Set[String], inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
-        val key   = kShow.show(kWit.value)
-        val value = vShow.show(vWit.value)
-
-        req.headers.get(key.toLowerCase).fold(BadRequestE[Out](s"missing header '$key'")) { raw =>
-          if (raw != value)
-            BadRequestE[Out](s"header '$key' has unexpected value '${raw}' - expected '${value}'")
-          else
-            next(request, extractedHeaderKeys + key, inAgg)
-        }
-      }
-    }
-
-  implicit def ignoreServerHeaderExtractor[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
+  implicit def ignoreServerHeaderElExtractor[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
       (implicit next: RouteExtractor[El, KIn, VIn, M, EIn]) =
     new RouteExtractor[shapeless.::[ServerHeader[K, V], El], KIn, VIn, M, EIn] {
       type Out = next.Out

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -10,7 +10,7 @@ final class ApiToEndpointLinkSpec extends Specification {
   case class Foo(name: String)
 
   "link api definitions to endpoint functions" >> { 
-    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Client('hello, 'world) :> Server('foo, 'bar) :> Get[Json, List[Foo]]
+    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Client.Header('hello, 'world) :> Server.Header('foo, 'bar) :> Get[Json, List[Foo]]
 
     val endpoint0 = derive[Option](Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
     endpoint0("john" :: 10 :: HNil) === Some(List(Foo("john")))

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -73,15 +73,11 @@ final class RouteExtractorSpec extends Specification {
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
       ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
 
-      val ext4 = extract(:= :> "foo" :> Client("Accept", "*") :> Get[Json, Foo])
+      val ext4 = extract(:= :> "foo" :> Server.Header("Accept", "*") :> Get[Json, Foo])
 
       ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
-      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
-      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
-
-      val ext5 = extract(:= :> "foo" :> Server("Accept", "*") :> Get[Json, Foo])
-
-      ext5(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === Right(HNil)
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === Right(HNil)
     }
 
     "body type" >> {

--- a/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
+++ b/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
@@ -72,7 +72,7 @@ final class ServeAndMountSpec extends Specification {
     }
 
     "check if route exists and return method" >> {
-      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Server("Hello", "*") :> Get[Json, List[Foo]]
+      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Server.Header("Hello", "*") :> Get[Json, List[Foo]]
       val endpoint = derive[Option](Api).from((name, sortByAge) => Some(List(Foo(name))))
       val served   = toList(endpoint)
 

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -6,71 +6,59 @@ import shapeless._
 sealed trait ApiList[H <: HList]
 
 /** Basic operations. */
-sealed trait ApiListWithOps[H <: HList] extends ApiList[H] {
+sealed trait MethodOps[H <: HList] {
 
   def :>[MT <: MediaType, A](body: TypeCarrier[ReqBodyElement[MT, A]]): WithBodyCons[MT, A, H] = WithBodyCons()
   def :>[M <: MethodElement](method: TypeCarrier[M]): ApiTypeCarrier[M :: H] = ApiTypeCarrier()
 }
 
-/** Initial element with empty api description. */
-case object EmptyCons extends ApiListWithOps[HNil] {
+sealed trait PathOps[H <: HList] {
 
-  def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: HNil] = PathCons()
-  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: HNil] = SegmentCons()
-  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: HNil] = QueryCons()  
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: HNil] = InputHeaderCons()
-  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: HNil] = FixedHeaderCons()
-  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: HNil] = ClientHeaderCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: HNil] = ServerHeaderCons()
+  def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
+  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
+}
+
+sealed trait HeaderOps[H <: HList] {
+
+  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
+  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderElCons[ClientHeaderElement[K, V] :: H] = ClientHeaderElCons()
+  def :>[K, V](client: TypeCarrier[ClientHeaderParam[K, V]]): ClientHeaderParamCons[ClientHeaderParam[K, V] :: H] = ClientHeaderParamCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderElCons[ServerHeaderElement[K, V] :: H] = ServerHeaderElCons()
+}
+
+/** Initial element with empty api description. */
+case object EmptyCons extends PathOps[HNil] with HeaderOps[HNil] with MethodOps[HNil] with ApiList[HNil] {
+
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: HNil] = QueryCons()
 }
 
 /** Last set element is a path. */
-final case class PathCons[H <: HList]() extends ApiListWithOps[H] {
-
-  def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
-  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()  
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
-  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
-  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
+final case class PathCons[H <: HList]() extends PathOps[H] with HeaderOps[H] with MethodOps[H] with ApiList[H] {
+  
+  def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
 }
 
 /** Last set element is a segment. */
-final case class SegmentCons[H <: HList]() extends ApiListWithOps[H] {
+final case class SegmentCons[H <: HList]() extends PathOps[H] with HeaderOps[H] with MethodOps[H] with ApiList[H] {
 
-  def :>[S](path: Witness.Lt[S]): PathCons[PathElement[S] :: H] = PathCons()
-  def :>[K, V](segment: TypeCarrier[SegmentParam[K, V]]): SegmentCons[SegmentParam[K, V] :: H] = SegmentCons()
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
-  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
-  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 /** Last set element is a query parameter. */
-final case class QueryCons[H <: HList]() extends ApiListWithOps[H]  {
+final case class QueryCons[H <: HList]() extends HeaderOps[H] with MethodOps[H] with ApiList[H] {
 
   def :>[K, V](query: TypeCarrier[QueryParam[K, V]]): QueryCons[QueryParam[K, V] :: H] = QueryCons()
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
-  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
-  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
 }
 
 /** Last set element is a header. */
-sealed trait HeaderCons[H <: HList] extends ApiListWithOps[H] {
-
-  def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
-  def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
-  def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderCons[ClientHeaderElement[K, V] :: H] = ClientHeaderCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderCons[ServerHeaderElement[K, V] :: H] = ServerHeaderCons()
-}
+sealed trait HeaderCons[H <: HList] extends HeaderOps[H] with MethodOps[H] with ApiList[H]
 
 final case class InputHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class FixedHeaderCons[H <: HList]() extends HeaderCons[H]
-final case class ClientHeaderCons[H <: HList]() extends HeaderCons[H]
-final case class ServerHeaderCons[H <: HList]() extends HeaderCons[H]
+final case class ClientHeaderElCons[H <: HList]() extends HeaderCons[H]
+final case class ClientHeaderParamCons[H <: HList]() extends HeaderCons[H]
+final case class ServerHeaderElCons[H <: HList]() extends HeaderCons[H]
 
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -10,8 +10,17 @@ package object dsl extends MethodToReqBodyLowPrio with MethodToStringLowPrio wit
   def Query[V]   = new PairTypeFromWitnessKey[QueryParam, V]
   def Header[V]  = new PairTypeFromWitnessKey[HeaderParam, V]
   def Header     = new PairTypeFromWitnesses[FixedHeaderElement]
-  def Client     = new PairTypeFromWitnesses[ClientHeaderElement]
-  def Server     = new PairTypeFromWitnesses[ServerHeaderElement]
+
+  object Client {
+
+    def Header    = new PairTypeFromWitnesses[ClientHeaderElement]
+    def Header[V] = new PairTypeFromWitnessKey[ClientHeaderParam, V]
+  }
+
+  object Server {
+
+    def Header    = new PairTypeFromWitnesses[ServerHeaderElement]
+  }
 
   type Json  = `Application/json`
   type Plain = `Text/plain`

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -18,9 +18,11 @@ sealed trait HeaderParam[K, V] extends ApiElement
 
 /** Type-container providing the name (singleton) and value type for a static header element. */
 sealed trait FixedHeaderElement[K, V] extends ApiElement
-/** Type-container providing the name (singleton) and value type for a static header element only used solely for the client. */
+/** Type-container providing the name (singleton) and value type for a static header element only used for the client. */
 sealed trait ClientHeaderElement[K, V] extends ApiElement
-/** Type-container providing the name (singleton) and value type for a static header element only used solely for the server. */
+/** Type-container providing the name (singleton) and value type for a header parameter only used for the client. */
+sealed trait ClientHeaderParam[K, V] extends ApiElement
+/** Type-container providing the name (singleton) and value type for a static header element only used for the server. */
 sealed trait ServerHeaderElement[K, V] extends ApiElement
 
 /** Type-container providing the media-type and value type for a request body. */

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -26,8 +26,13 @@ final case class HeaderListBuilder[H <: HList]() {
     def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[HeaderParam[K, V] :: H] = HeaderListBuilder()
   }
 
+  final class ClientWitnessDerivation[V] {
+    def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[ClientHeaderParam[K, V] :: H] = HeaderListBuilder()
+  }
+
   def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
   def add[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[FixedHeaderElement[K, V] :: H] = HeaderListBuilder()
+  def client[V]: ClientWitnessDerivation[V] = new ClientWitnessDerivation[V]
   def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
   def server[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ServerHeaderElement[K, V] :: H] = HeaderListBuilder()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -24,7 +24,7 @@ sealed trait PostWithBodyCall extends MethodType
 sealed trait DeleteCall extends MethodType
 
 /** Transforms a [[MethodType]] to a `String`. */
-@implicitNotFound("""Missing String transformation for this method = ${M}.""")
+@implicitNotFound("Missing String transformation for this method = ${M}.")
 trait MethodToString[M <: MethodType] {
 
   def show: String

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -13,6 +13,7 @@ sealed trait HeaderInput extends ApiOp
 
 sealed trait FixedHeader[K, V] extends ApiOp
 sealed trait ClientHeader[K, V] extends ApiOp
+sealed trait ClientHeaderInput extends ApiOp
 sealed trait ServerHeader[K, V] extends ApiOp
 
 trait MethodType extends ApiOp
@@ -59,16 +60,16 @@ trait ApiTransformer {
   implicit def pathElementTransformer[S, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[PathElement[S], (El, KIn, VIn, M, Out), (S :: El, KIn, VIn, M, Out)]
 
-  implicit def segmentElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def segmentParamTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[SegmentParam[S, A], (El, KIn, VIn, M, Out), (SegmentInput :: El, S :: KIn, A :: VIn, M, Out)]
 
-  implicit def queryElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def queryParamTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[QueryParam[S, A], (El, KIn, VIn, M, Out), (QueryInput :: El, S :: KIn, A :: VIn, M, Out)]
 
-  implicit def queryListElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def queryListParamTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[QueryParam[S, List[A]], (El, KIn, VIn, M, Out), (QueryInput :: El, S :: KIn, List[A] :: VIn, M, Out)]
 
-  implicit def headerElementTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+  implicit def headerParamTransformer[S, A, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[HeaderParam[S, A], (El, KIn, VIn, M, Out), (HeaderInput :: El, S :: KIn, A :: VIn, M, Out)]
 
   implicit def fixedHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
@@ -76,6 +77,9 @@ trait ApiTransformer {
 
   implicit def clientHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[ClientHeaderElement[K, V], (El, KIn, VIn, M, Out), (ClientHeader[K, V] :: El, KIn, VIn, M, Out)]
+
+  implicit def clientHeaderParamTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ClientHeaderParam[K, V], (El, KIn, VIn, M, Out), (ClientHeaderInput :: El, K :: KIn, V :: VIn, M, Out)]
 
   implicit def serverHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[ServerHeaderElement[K, V], (El, KIn, VIn, M, Out), (ServerHeader[K, V] :: El, KIn, VIn, M, Out)]

--- a/shared/src/main/scala/typedapi/util/Decoder.scala
+++ b/shared/src/main/scala/typedapi/util/Decoder.scala
@@ -1,4 +1,4 @@
-package typedapi.client.js
+package typedapi.util
 
 import scala.language.higherKinds
 

--- a/shared/src/main/scala/typedapi/util/Encoder.scala
+++ b/shared/src/main/scala/typedapi/util/Encoder.scala
@@ -1,4 +1,4 @@
-package typedapi.client.js
+package typedapi.util
 
 import scala.language.higherKinds
 

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -60,8 +60,9 @@ object ApiDslSpec {
   test.illTyped("_baseH :> Query[Int](fooW)")
   testCompile(_baseH :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: _BaseH]
   testCompile(_baseH :> Header(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: FixedHeaderElement[fooW.T, testW.T] :: _BaseH]
-  testCompile(_baseH :> Client(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: ClientHeaderElement[fooW.T, testW.T] :: _BaseH]
-  testCompile(_baseH :> Server(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: ServerHeaderElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Client.Header[String](fooW))[ClientHeaderParam[fooW.T, String] :: _BaseH]
+  testCompile(_baseH :> Client.Header(fooW, testW))[ClientHeaderElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Server.Header(fooW, testW))[ServerHeaderElement[fooW.T, testW.T] :: _BaseH]
   testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/json`, Foo] :: _BaseH]
 
   // request body: add put or post

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -28,6 +28,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: QueryParam[fooW.T, List[String]] :: HNil, (QueryInput :: HNil, fooW.T :: HNil, List[String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: HeaderParam[fooW.T, String] :: HNil, (HeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ClientHeaderParam[fooW.T, String] :: HNil, (ClientHeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderElement[fooW.T, barW.T] :: HNil, (ClientHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ServerHeaderElement[fooW.T, barW.T] :: HNil, (ServerHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 


### PR DESCRIPTION
This PR adds:
  - client-side support for Scalaj-Http
  - input Header parameters for the client-side (and improved dsl)
  ```Scala
   val Api = := :> "headers" :> Client.Header[String]("My-Header") :> Server.Header("Foo", "Bar") :> Get[Json, User]
   ```
  - add raw execution to clients (you get the raw response):
  ```Scala
  val get = derive(Api)
  get().run[IO].raw(cm)
  ```
  