### PR TITLE
Added matching header to server-side

### DIFF
--- a/client/src/main/scala/typedapi/client/FilterServerElements.scala
+++ b/client/src/main/scala/typedapi/client/FilterServerElements.scala
@@ -1,6 +1,6 @@
 package typedapi.client
 
-import typedapi.shared.ServerHeaderElement
+import typedapi.shared._
 import shapeless._
 
 //TODO replace with Typelevelfoldleft
@@ -24,7 +24,11 @@ object FilterServerElements extends FilterServerElementsLowPrio {
 
   type Aux[H <: HList, Out0 <: HList] = FilterServerElements[H] { type Out = Out0 }
 
-  implicit def filterServerEl[K, V, T <: HList](implicit next: FilterServerElements[T]) = new FilterServerElements[ServerHeaderElement[K, V] :: T] {
+  implicit def filterServerHeaderMatch[K, V, T <: HList](implicit next: FilterServerElements[T]) = new FilterServerElements[ServerHeaderMatchParam[K, V] :: T] {
+    type Out = next.Out
+  }
+
+  implicit def filterServerHeaderSend[K, V, T <: HList](implicit next: FilterServerElements[T]) = new FilterServerElements[ServerHeaderSendElement[K, V] :: T] {
     type Out = next.Out
   }
 }

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -71,7 +71,7 @@ final class RequestDataBuilderSpec extends Specification {
       }
 
       "ignore server elements" >> {
-        val api0 = derive(:= :> Server.Header('s1, 's2) :> Client.Header[Int]('i0) :> Get[Json, ReqInput])
+        val api0 = derive(:= :> Server.Match[String]("Hello-") :> Server.Send("a", "b") :> Client.Header[Int]('i0) :> Get[Json, ReqInput])
         api0(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
       }
 
@@ -88,7 +88,7 @@ final class RequestDataBuilderSpec extends Specification {
 
     "composition" >> {
       val api = 
-        (:= :> "find" :> Server.Header("Test", "ignore") :> Get[Json, ReqInput]) :|:
+        (:= :> "find" :> Server.Match[String]("Hello-") :> Server.Send("a", "b") :> Get[Json, ReqInput]) :|:
         (:= :> "fetch" :> Segment[String]('type) :> Get[Json, ReqInput]) :|:
         (:= :> "store" :> ReqBody[Json, Int] :> Post[Json, ReqInputWithBody[Int]])
 

--- a/docs/example/client-js/src/main/scala/Client.scala
+++ b/docs/example/client-js/src/main/scala/Client.scala
@@ -23,7 +23,7 @@ object Client {
   ))
   implicit val encoder = typedapi.util.Encoder[Future, User](user => Future.successful(user.asJson.noSpaces))
 
-  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client) = deriveAll(FromDsl.MyApi)
+  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, matches) = deriveAll(FromDsl.MyApi)
 
   def main(args: Array[String]): Unit = {
     val cm = ClientManager(Ajax, "http://localhost", 9000)

--- a/docs/example/client-jvm/src/main/scala/Client.scala
+++ b/docs/example/client-jvm/src/main/scala/Client.scala
@@ -10,7 +10,7 @@ object Client {
   implicit val decoder = jsonOf[IO, User]
   implicit val encoder = jsonEncoderOf[IO, User]
 
-  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client) = deriveAll(FromDsl.MyApi)
+  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, matches) = deriveAll(FromDsl.MyApi)
 
   def main(args: Array[String]): Unit = {
     import User._

--- a/docs/example/server/src/main/scala/Server.scala
+++ b/docs/example/server/src/main/scala/Server.scala
@@ -24,8 +24,9 @@ object Server {
   val header: String => IO[User] = consumer => IO.pure(User("found: " + consumer, 42))
   val fixed: () => IO[User] = get
   val client: () => IO[User] = get
+  val matching: Set[String] => IO[User] = matches => IO.pure(User(matches.mkString(""), 42))
 
-  val endpoints = deriveAll[IO](FromDefinition.MyApi).from(get, put, post, delete, path, putBody, segment, search, header, fixed, client)
+  val endpoints = deriveAll[IO](FromDefinition.MyApi).from(get, put, post, delete, path, putBody, segment, search, header, fixed, client, matching)
 
   def main(args: Array[String]): Unit = {
     import org.http4s.server.blaze.BlazeBuilder

--- a/docs/example/shared/src/main/scala/Apis.scala
+++ b/docs/example/shared/src/main/scala/Apis.scala
@@ -9,25 +9,26 @@ object FromDsl {
 
   val MyApi = 
     // basic GET request
-    (:= :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     // basic PUT request
-    (:= :> Server("Access-Control-Allow-Origin", "*") :> Put[Json, User]) :|:
+    (:= :> Server.Send("Access-Control-Allow-Origin", "*") :> Put[Json, User]) :|:
     // basic POST request
-    (:= :> Server("Access-Control-Allow-Origin", "*") :> Post[Json, User]) :|:
+    (:= :> Server.Send("Access-Control-Allow-Origin", "*") :> Post[Json, User]) :|:
     // basic DELETE request
-    (:= :> Server("Access-Control-Allow-Origin", "*") :> Delete[Json, User]) :|:
+    (:= :> Server.Send("Access-Control-Allow-Origin", "*") :> Delete[Json, User]) :|:
     // define a path
-    (:= :> "my" :> "path" :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "my" :> "path" :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     // add a request body
-    (:= :> "with" :> "body" :> Server("Access-Control-Allow-Origin", "*") :> ReqBody[Json, User] :> Put[Json, User]) :|:
+    (:= :> "with" :> "body" :> Server.Send("Access-Control-Allow-Origin", "*") :> ReqBody[Json, User] :> Put[Json, User]) :|:
     // add segments
-    (:= :> "name" :> Segment[String]("name") :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "name" :> Segment[String]("name") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     // add query
-    (:= :> "search" :> "user" :> Query[String]("name") :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "search" :> "user" :> Query[String]("name") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     // add header
-    (:= :> "header" :> Header[String]("consumer") :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
-    (:= :> "header" :> "fixed" :> Header("consumer", "me") :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
-    (:= :> "header" :> "client" :> Client("client", "me") :> Server("Access-Control-Allow-Origin", "*") :> Get[Json, User])
+    (:= :> "header" :> Header[String]("consumer") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "fixed" :> Header("consumer", "me") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "client" :> Client.Header("client", "me") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "server" :> Server.Match[String]("Control-") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User])
 }
 
 object FromDefinition {
@@ -36,23 +37,24 @@ object FromDefinition {
 
   val MyApi =
     // basic GET request
-    api(Get[Json, User], headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // basic PUT request
-    api(Put[Json, User], headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Put[Json, User], headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // basic POST request
-    api(Post[Json, User], headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Post[Json, User], headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // basic Delete request
-    api(Delete[Json, User], headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Delete[Json, User], headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // define a path
-    api(Get[Json, User], Root / "my" / "path", headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "my" / "path", headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // add a request body
-    apiWithBody(Put[Json, User], ReqBody[Json, User], Root / "with" / "body", headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    apiWithBody(Put[Json, User], ReqBody[Json, User], Root / "with" / "body", headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // add segments
-    api(Get[Json, User], Root / "name" / Segment[String]("name"), headers = Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "name" / Segment[String]("name"), headers = Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // add query
-    api(Get[Json, User], Root / "search" / "user", Queries.add[String]("name"), Headers.server("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "search" / "user", Queries.add[String]("name"), Headers.serverSend("Access-Control-Allow-Origin", "*")) :|:
     // add header
-    api(Get[Json, User], Root / "header", headers = Headers.add[String]("consumer").server("Access-Control-Allow-Origin", "*")) :|:
-    api(Get[Json, User], Root / "header" / "fixed", headers = Headers.add("consumer", "me").server("Access-Control-Allow-Origin", "*")) :|:
-    api(Get[Json, User], Root / "header", headers = Headers.client("client", "me").server("Access-Control-Allow-Origin", "*"))
+    api(Get[Json, User], Root / "header", headers = Headers.add[String]("consumer").serverSend("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "header" / "fixed", headers = Headers.add("consumer", "me").serverSend("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "header" / "client", headers = Headers.client("client", "me").serverSend("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "header" / "server", headers = Headers.serverMatch[String]("Control-").serverSend("Access-Control-Allow-Origin", "*"))
 }

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -42,11 +42,12 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
     }
     
     "headers" >> {
-      h0(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
-      h1().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
-      h2("jim").run[Future](cm) must beEqualTo(User("jim", 27)).awaitFor(timeout)
-      h3().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
-      h4().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      header(42).run[Future](cm) must beEqualTo(User("foo", 42)).awaitFor(timeout)
+      fixed().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      clInH("jim").run[Future](cm) must beEqualTo(User("jim", 27)).awaitFor(timeout)
+      clFixH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      serMatchH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      serSendH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -30,11 +30,12 @@ final class Http4sClientSupportSpec extends Specification {
     }
     
     "headers" >> {
-      h0(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
-      h1().run[IO](cm).unsafeRunSync() === User("joe", 27)
-      h2("jim").run[IO](cm).unsafeRunSync === User("jim", 27)
-      h3().run[IO](cm).unsafeRunSync() === User("joe", 27)
-      h4().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      header(42).run[IO](cm).unsafeRunSync() === User("foo", 42)
+      fixed().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      clInH("jim").run[IO](cm).unsafeRunSync === User("jim", 27)
+      clFixH().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      serMatchH().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      serSendH().run[IO](cm).unsafeRunSync() === User("joe", 27)
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -27,7 +27,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, h0, h1, h2, h3, h4, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Blocking](cm) === Right(User("foo", 27))
@@ -39,11 +39,12 @@ final class ScalajHttpClientSupportSpec extends Specification {
     }
     
     "headers" >> {
-      h0(42).run[Blocking](cm) === Right(User("foo", 42))
-      h1().run[Blocking](cm) === Right(User("joe", 27))
-      h2("jim").run[Blocking](cm) === Right(User("jim", 27))
-      h3().run[Blocking](cm) === Right(User("joe", 27))
-      h4().run[Blocking](cm) === Right(User("joe", 27))
+      header(42).run[Blocking](cm) === Right(User("foo", 42))
+      fixed().run[Blocking](cm) === Right(User("joe", 27))
+      clInH("jim").run[Blocking](cm) === Right(User("jim", 27))
+      clFixH().run[Blocking](cm) === Right(User("joe", 27))
+      serMatchH().run[Blocking](cm) === Right(User("joe", 27))
+      serSendH().run[Blocking](cm) === Right(User("joe", 27))
     }
 
     "methods" >> {

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -56,8 +56,11 @@ object TestServer {
 
       Ok(User(value, 27))
 
-    case req @ GET -> Root / "header" / "server" =>
+    case req @ GET -> Root / "header" / "server" / "send" =>
       Ok(User("joe", 27)).map(resp => resp.copy(headers = resp.headers put Header("Hello", "*")))
+
+    case req @ GET -> Root / "header" / "server" / "match" =>
+      Ok(User("joe", 27))
 
     case GET -> Root => Ok(User("foo", 27))
     case PUT -> Root => Ok(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -12,7 +12,8 @@ package object tests {
     (:= :> "header" :> "fixed" :> Header("Hello", "*") :> Get[Json, User]) :|:
     (:= :> "header" :> "input" :> "client" :> Client.Header[String]("Hello") :> Get[Json, User]) :|:
     (:= :> "header" :> "client" :> Client.Header("Hello", "*") :> Get[Json, User]) :|:
-    (:= :> "header" :> "server" :> Server.Header("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "server" :> "match" :> Server.Match[String]("test") :> Get[Json, User]) :|:
+    (:= :> "header" :> "server" :> "send" :> Server.Send("Hello", "*") :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:
     (:= :> Put[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -51,13 +51,18 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
       client.fetch[Option[Header]](
         Request[IO](
           method = GET,
-          uri = Uri.fromString(s"http://localhost:$port/header/server").right.get
+          uri = Uri.fromString(s"http://localhost:$port/header/server/send").right.get
         )
       )(
         resp => IO {
           resp.headers.toList.find(_.name.toString == "Hello")
         }
       ).unsafeRunSync() === Some(Header("Hello", "*"))
+      client.expect[User](Request[IO](
+        method = GET,
+        uri = Uri.fromString(s"http://localhost:$port/header/server/match").right.get,
+        headers = Headers(Header("test", "foo"), Header("testy", "bar"), Header("meh", "NONO"))
+      )).unsafeRunSync() === User("foobar", 27)
       client.fetch[Option[Header]](
         Request[IO](
           method = OPTIONS,
@@ -86,6 +91,7 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
   val query: Int => F[User] = age => Applicative[F].pure(User("joe", age))
   val header: Int => F[User] = age => Applicative[F].pure(User("joe", age))
   val fixed: () => F[User] = () => Applicative[F].pure(User("joe", 27))
+  val matching: Set[String] => F[User] = matches => Applicative[F].pure(User(matches.mkString(""), 27))
   val get: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val put: () => F[User] = () => Applicative[F].pure(User("joe", 27))
   val putB: User => F[User] = user => Applicative[F].pure(user)

--- a/server/src/main/scala/typedapi/server/EndpointExecutor.scala
+++ b/server/src/main/scala/typedapi/server/EndpointExecutor.scala
@@ -18,7 +18,7 @@ sealed trait EndpointExecutor[El <: HList, KIn <: HList, VIn <: HList, M <: Meth
   type Out
 
   def extract(eReq: EndpointRequest, endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut]): Either[ExtractionError, ROut] = 
-    endpoint.extractor(eReq, Set.empty, HNil)
+    endpoint.extractor(eReq, HNil)
 
   def apply(req: R, eReq: EndpointRequest, endpoint: Endpoint[El, KIn, VIn, M, ROut, F, FOut]): Either[ExtractionError, Out]
 }

--- a/server/src/main/scala/typedapi/server/ServerHeaderExtractor.scala
+++ b/server/src/main/scala/typedapi/server/ServerHeaderExtractor.scala
@@ -28,7 +28,7 @@ object ServerHeaderExtractor extends ServerHeaderExtractorLowPrio {
 
   implicit def serverHeaderExtractCase[K, V, T <: HList]
       (implicit kWit: Witness.Aux[K], kShow: WitnessToString[K], vWit: Witness.Aux[V], vShow: WitnessToString[V], next: ServerHeaderExtractor[T]) = 
-    new ServerHeaderExtractor[ServerHeader[K, V] :: T] {
+    new ServerHeaderExtractor[ServerHeaderSend[K, V] :: T] {
       def apply(agg: Map[String, String]): Map[String, String] = {
         val key   = kShow.show(kWit.value)
         val value = vShow.show(vWit.value)

--- a/server/src/main/scala/typedapi/server/package.scala
+++ b/server/src/main/scala/typedapi/server/package.scala
@@ -18,7 +18,7 @@ package object server extends TypeLevelFoldLeftLowPrio
       (implicit executor: EndpointExecutor.Aux[Req, El, KIn, VIn, M, ROut, F, FOut, Resp], mounting: MountEndpoints.Aux[S, Req, Resp, Out]): Out =
     mounting(server, List(new Serve[executor.R, executor.Out] {
       def options(eReq: EndpointRequest): Option[(String, Map[String, String])] = {
-        endpoint.extractor(eReq, Set.empty, HNil) match {
+        endpoint.extractor(eReq, HNil) match {
           case Right(_) => Some((endpoint.method, endpoint.headers))
           case _        => None
         }
@@ -35,7 +35,7 @@ package object server extends TypeLevelFoldLeftLowPrio
       at[Endpoint[El, KIn, VIn, M, ROut, F, FOut]] { endpoint =>
         new Serve[executor.R, executor.Out] {
           def options(eReq: EndpointRequest): Option[(String, Map[String, String])] = {
-            endpoint.extractor(eReq, Set.empty, HNil) match {
+            endpoint.extractor(eReq, HNil) match {
               case Right(_) => Some((endpoint.method, endpoint.headers))
               case _        => None
             }

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -10,16 +10,15 @@ final class ApiToEndpointLinkSpec extends Specification {
   case class Foo(name: String)
 
   "link api definitions to endpoint functions" >> { 
-    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> Query[Int]('limit) :> Client.Header('hello, 'world) :> Server.Header('foo, 'bar) :> Get[Json, List[Foo]]
+    val Api = := :> "find" :> typedapi.dsl.Segment[String]('name) :> 
+                    Query[Int]('limit) :> 
+                    Client.Header('hello, 'world) :> 
+                    Server.Send('foo, 'bar) :> Server.Match[String]("hi") :>
+                    Get[Json, List[Foo]]
 
-    val endpoint0 = derive[Option](Api).from((name, limit) => Some(List(Foo(name)).take(limit)))
-    endpoint0("john" :: 10 :: HNil) === Some(List(Foo("john")))
+    val endpoint0 = derive[Option](Api).from((name, limit, hi) => Some(List(Foo(name)).take(limit)))
+    endpoint0("john" :: 10 :: Set("whats", "up") :: HNil) === Some(List(Foo("john")))
     endpoint0.headers == Map("foo" -> "bar")
     endpoint0.method == "GET"
-
-    val endpoint1 = derive[Option](Api).from((name, limit) => Option(List(Foo(name)).take(limit)))
-    endpoint1("john" :: 10 :: HNil) === Some(List(Foo("john")))
-    endpoint1.headers == Map("foo" -> "bar")
-    endpoint1.method == "GET"
   }
 }

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -18,113 +18,118 @@ final class RouteExtractorSpec extends Specification {
     "no data" >> {
       val ext = extract(:= :> "hello" :> "world" :> Get[Json, Foo])
       
-      ext(EndpointRequest("GET", List("hello", "world"), Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
-      ext(EndpointRequest("GET", List("hello", "wrong"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext(EndpointRequest("GET", List("hello"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", List("hello", "world"), Map.empty, Map.empty), HNil) === Right(HNil)
+      ext(EndpointRequest("GET", List("hello", "wrong"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", List("hello"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", Nil, Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
     }
 
     "segments" >> {
       val ext = extract(:= :> "foo" :> Segment[Int]('age) :> Get[Json, Foo])
 
-      ext(EndpointRequest("GET", List("foo", "0"), Map.empty, Map.empty), Set.empty, HNil) === Right(0 :: HNil)
-      ext(EndpointRequest("GET", List("foo", "wrong"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", List("foo", "0"), Map.empty, Map.empty), HNil) === Right(0 :: HNil)
+      ext(EndpointRequest("GET", List("foo", "wrong"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext(EndpointRequest("GET", Nil, Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
     }
 
     "queries" >> {
       val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Get[Json, Foo])
 
-      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), Set.empty, HNil) === Right(0 :: HNil)
-      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("wrong")), Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("query 'age' has not type Int")
-      ext0(EndpointRequest("GET", List("foo"), Map("wrong" -> List("0")), Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing query 'age'")
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing query 'age'")
-      ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), HNil) === Right(0 :: HNil)
+      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("wrong")), Map.empty), HNil) === RouteExtractor.BadRequestE("query 'age' has not type Int")
+      ext0(EndpointRequest("GET", List("foo"), Map("wrong" -> List("0")), Map.empty), HNil) === RouteExtractor.BadRequestE("missing query 'age'")
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === RouteExtractor.BadRequestE("missing query 'age'")
+      ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
 
       val ext1 = extract(:= :> "foo" :> Query[Option[Int]]('age) :> Get[Json, Foo])
 
-      ext1(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), Set.empty, HNil) === Right(Some(0) :: HNil)
-      ext1(EndpointRequest("GET", List("foo"), Map("wrong" -> List("0")), Map.empty), Set.empty, HNil) === Right(None :: HNil)
+      ext1(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map.empty), HNil) === Right(Some(0) :: HNil)
+      ext1(EndpointRequest("GET", List("foo"), Map("wrong" -> List("0")), Map.empty), HNil) === Right(None :: HNil)
 
       val ext2 = extract(:= :> "foo" :> Query[List[Int]]('age) :> Get[Json, Foo])
 
-      ext2(EndpointRequest("GET", List("foo"), Map("age" -> List("0", "1")), Map.empty), Set.empty, HNil) === Right(List(0, 1) :: HNil)
-      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(Nil :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map("age" -> List("0", "1")), Map.empty), HNil) === Right(List(0, 1) :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === Right(Nil :: HNil)
     }
 
     "headers" >> {
       val ext0 = extract(:= :> "foo" :> Header[Int]('age) :> Get[Json, Foo])
 
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(0 :: HNil)
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'age' has not type Int")
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "0")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'age'")
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'age'")
-      ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), HNil) === Right(0 :: HNil)
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "wrong")), HNil) === RouteExtractor.BadRequestE("header 'age' has not type Int")
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "0")), HNil) === RouteExtractor.BadRequestE("missing header 'age'")
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === RouteExtractor.BadRequestE("missing header 'age'")
+      ext0(EndpointRequest("GET", List("foo", "bar"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
 
       val ext2 = extract(:= :> "foo" :> Header[Option[Int]]('age) :> Get[Json, Foo])
 
-      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), Set.empty, HNil) === Right(Some(0) :: HNil)
-      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === Right(None :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), HNil) === Right(Some(0) :: HNil)
+      ext2(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === Right(None :: HNil)
 
       val ext3 = extract(:= :> "foo" :> Header("Accept", "*") :> Get[Json, Foo])
 
-      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
-      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
-      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), HNil) === Right(HNil)
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), HNil) === RouteExtractor.BadRequestE("missing header 'Accept'")
+      ext3(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), HNil) === RouteExtractor.BadRequestE("header 'Accept' has unexpected value 'wrong' - expected '*'")
 
-      val ext4 = extract(:= :> "foo" :> Server.Header("Accept", "*") :> Get[Json, Foo])
+      val ext4 = extract(:= :> "foo" :> Server.Send("Accept", "*") :> Get[Json, Foo])
 
-      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "*")), Set.empty, HNil) === Right(HNil)
-      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("wrong" -> "*")), Set.empty, HNil) === Right(HNil)
-      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map("accept" -> "wrong")), Set.empty, HNil) === Right(HNil)
+      ext4(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === Right(HNil)
+
+      val ext6 = extract(:= :> "foo" :> Server.Match[Int]("age") :> Get[Json, Foo])
+
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), HNil) === Right(Set(0) :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age-and-what-not" -> "0")), HNil) === Right(Set(0) :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("nope" -> "0")), HNil) === Right(Set.empty :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age-" -> "hello")), HNil) === RouteExtractor.BadRequestE("header 'age-' has not type Int")
     }
 
     "body type" >> {
       val ext0 = extract(:= :> ReqBody[Json, Foo] :> Put[Json, Foo])
 
-      ext0(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
-      ext0(EndpointRequest("PUT", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext0(EndpointRequest("OPTIONS", List("foo", "bar"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("PUT", Nil, Map.empty, Map.empty), HNil) === Right((BodyType[Foo], HNil))
+      ext0(EndpointRequest("PUT", List("foo", "bar"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("OPTIONS", List("foo", "bar"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
 
       val ext1 = extract(:= :> ReqBody[Json, Foo] :> Post[Json, Foo])
 
-      ext1(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
-      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right((BodyType[Foo], HNil))
+      ext1(EndpointRequest("POST", Nil, Map.empty, Map.empty), HNil) === Right((BodyType[Foo], HNil))
+      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), HNil) === Right((BodyType[Foo], HNil))
     }
 
     "methods" >> {
       val ext0 = extract(:= :> Get[Json, Foo])
 
-      ext0(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
-      ext0(EndpointRequest("WRONG", Nil, Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), Set.empty, HNil) === RouteExtractor.NotFoundE
-      ext0(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext0(EndpointRequest("GET", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
+      ext0(EndpointRequest("WRONG", Nil, Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("GET", List("foo"), Map.empty, Map.empty), HNil) === RouteExtractor.NotFoundE
+      ext0(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
 
       val ext1 = extract(:= :> Put[Json, Foo])
 
-      ext1(EndpointRequest("PUT", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
-      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext1(EndpointRequest("PUT", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
+      ext1(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
 
       val ext2 = extract(:= :> Post[Json, Foo])
 
-      ext2(EndpointRequest("POST", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
-      ext2(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext2(EndpointRequest("POST", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
+      ext2(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
 
       val ext3 = extract(:= :> Delete[Json, Foo])
 
-      ext3(EndpointRequest("DELETE", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
-      ext3(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext3(EndpointRequest("DELETE", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
+      ext3(EndpointRequest("OPTIONS", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
     }
 
     "combinations" >> {
       val ext0 = extract(:= :> "foo" :> Query[Int]('age) :> Header[String]('id) :> Get[Json, Foo])
 
-      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map("id" -> "john")), Set.empty, HNil) === Right(0 :: "john" :: HNil)
+      ext0(EndpointRequest("GET", List("foo"), Map("age" -> List("0")), Map("id" -> "john")), HNil) === Right(0 :: "john" :: HNil)
 
       val ext1 = extract(:= :> Get[Json, Foo])
 
-      ext1(EndpointRequest("GET", Nil, Map.empty, Map.empty), Set.empty, HNil) === Right(HNil)
+      ext1(EndpointRequest("GET", Nil, Map.empty, Map.empty), HNil) === Right(HNil)
     }
   }
 }

--- a/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
+++ b/server/src/test/scala/typedapi/server/ServeAndMountSpec.scala
@@ -47,7 +47,7 @@ final class ServeAndMountSpec extends Specification {
                                                                                         (implicit executor: EndpointExecutor[El, KIn, VIn, M, ROut, F, FOut]): List[Serve[executor.R, executor.Out]] = 
     List(new Serve[executor.R, executor.Out] {
       def options(eReq: EndpointRequest): Option[(String, Map[String, String])] = {
-        endpoint.extractor(eReq, Set.empty, HNil) match {
+        endpoint.extractor(eReq, HNil) match {
           case Right(_) => Some((endpoint.method, endpoint.headers))
           case _        => None
         }
@@ -72,7 +72,7 @@ final class ServeAndMountSpec extends Specification {
     }
 
     "check if route exists and return method" >> {
-      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Server.Header("Hello", "*") :> Get[Json, List[Foo]]
+      val Api      = := :> "find" :> "user" :> Segment[String]('name) :> Query[Int]('sortByAge) :> Server.Send("Hello", "*") :> Get[Json, List[Foo]]
       val endpoint = derive[Option](Api).from((name, sortByAge) => Some(List(Foo(name))))
       val served   = toList(endpoint)
 

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -24,7 +24,8 @@ sealed trait HeaderOps[H <: HList] {
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
   def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderElCons[ClientHeaderElement[K, V] :: H] = ClientHeaderElCons()
   def :>[K, V](client: TypeCarrier[ClientHeaderParam[K, V]]): ClientHeaderParamCons[ClientHeaderParam[K, V] :: H] = ClientHeaderParamCons()
-  def :>[K, V](server: TypeCarrier[ServerHeaderElement[K, V]]): ServerHeaderElCons[ServerHeaderElement[K, V] :: H] = ServerHeaderElCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderMatchParam[K, V]]): ServerHeaderMatchParamCons[ServerHeaderMatchParam[K, V] :: H] = ServerHeaderMatchParamCons()
+  def :>[K, V](server: TypeCarrier[ServerHeaderSendElement[K, V]]): ServerHeaderSendElCons[ServerHeaderSendElement[K, V] :: H] = ServerHeaderSendElCons()
 }
 
 /** Initial element with empty api description. */
@@ -58,7 +59,8 @@ final case class InputHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class FixedHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class ClientHeaderElCons[H <: HList]() extends HeaderCons[H]
 final case class ClientHeaderParamCons[H <: HList]() extends HeaderCons[H]
-final case class ServerHeaderElCons[H <: HList]() extends HeaderCons[H]
+final case class ServerHeaderMatchParamCons[H <: HList]() extends HeaderCons[H]
+final case class ServerHeaderSendElCons[H <: HList]() extends HeaderCons[H]
 
 /** Last set element is a request body. */
 final case class WithBodyCons[BMT <: MediaType, Bd, H <: HList]() extends ApiList[H] {

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -19,7 +19,8 @@ package object dsl extends MethodToReqBodyLowPrio with MethodToStringLowPrio wit
 
   object Server {
 
-    def Header    = new PairTypeFromWitnesses[ServerHeaderElement]
+    def Send      = new PairTypeFromWitnesses[ServerHeaderSendElement]
+    def Match[V]  = new PairTypeFromWitnessKey[ServerHeaderMatchParam, V]
   }
 
   type Json  = `Application/json`

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -22,8 +22,10 @@ sealed trait FixedHeaderElement[K, V] extends ApiElement
 sealed trait ClientHeaderElement[K, V] extends ApiElement
 /** Type-container providing the name (singleton) and value type for a header parameter only used for the client. */
 sealed trait ClientHeaderParam[K, V] extends ApiElement
-/** Type-container providing the name (singleton) and value type for a static header element only used for the server. */
-sealed trait ServerHeaderElement[K, V] extends ApiElement
+/** Type-container providing the name (singleton) and value type for a static header element sent by server. */
+sealed trait ServerHeaderSendElement[K, V] extends ApiElement
+/** Type-container providing the name (singleton) and value type describing a sub-string headers have to match only used for the server. */
+sealed trait ServerHeaderMatchParam[K, V] extends ApiElement
 
 /** Type-container providing the media-type and value type for a request body. */
 sealed trait ReqBodyElement[MT <: MediaType, A] extends ApiElement

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -25,14 +25,21 @@ final case class HeaderListBuilder[H <: HList]() {
   final class WitnessDerivation[V] {
     def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[HeaderParam[K, V] :: H] = HeaderListBuilder()
   }
+  def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
+  
+  def add[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[FixedHeaderElement[K, V] :: H] = HeaderListBuilder()
 
   final class ClientWitnessDerivation[V] {
     def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[ClientHeaderParam[K, V] :: H] = HeaderListBuilder()
   }
-
-  def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
-  def add[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[FixedHeaderElement[K, V] :: H] = HeaderListBuilder()
   def client[V]: ClientWitnessDerivation[V] = new ClientWitnessDerivation[V]
-  def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
-  def server[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ServerHeaderElement[K, V] :: H] = HeaderListBuilder()
+  
+def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
+
+  final class ServerMatchWitnessDerivation[V] {
+    def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[ServerHeaderMatchParam[K, V] :: H] = HeaderListBuilder()
+  }
+  def serverMatch[V]: ServerMatchWitnessDerivation[V] = new ServerMatchWitnessDerivation[V]
+
+  def serverSend[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ServerHeaderSendElement[K, V] :: H] = HeaderListBuilder()
 }

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -19,7 +19,8 @@ final case class QueryListBuilder[Q <: HList]() {
   def add[V]: WitnessDerivation[V] = new WitnessDerivation[V]
 }
 
-/** Typecarrier to construct a set of headers from [[HeaderParam]]s, [[FixedHeaderElement]]s, [[ClientHeaderElement]]s and [[ServerHeaderElement]]s. */
+/** Typecarrier to construct a set of headers from [[HeaderParam]]s, [[FixedHeaderElement]]s, [[ClientHeaderElement]]s, 
+    [[ServerHeaderSendElement]]s and [ServerHeaderMatchParam]]s. */
 final case class HeaderListBuilder[H <: HList]() {
 
   final class WitnessDerivation[V] {

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -14,7 +14,8 @@ sealed trait HeaderInput extends ApiOp
 sealed trait FixedHeader[K, V] extends ApiOp
 sealed trait ClientHeader[K, V] extends ApiOp
 sealed trait ClientHeaderInput extends ApiOp
-sealed trait ServerHeader[K, V] extends ApiOp
+sealed trait ServerHeaderSend[K, V] extends ApiOp
+sealed trait ServerHeaderMatchInput extends ApiOp
 
 trait MethodType extends ApiOp
 sealed trait GetCall extends MethodType
@@ -81,8 +82,11 @@ trait ApiTransformer {
   implicit def clientHeaderParamTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[ClientHeaderParam[K, V], (El, KIn, VIn, M, Out), (ClientHeaderInput :: El, K :: KIn, V :: VIn, M, Out)]
 
-  implicit def serverHeaderElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
-    at[ServerHeaderElement[K, V], (El, KIn, VIn, M, Out), (ServerHeader[K, V] :: El, KIn, VIn, M, Out)]
+  implicit def serverHeaderSendElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ServerHeaderSendElement[K, V], (El, KIn, VIn, M, Out), (ServerHeaderSend[K, V] :: El, KIn, VIn, M, Out)]
+
+  implicit def serverHeaderMatchParamTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ServerHeaderMatchParam[K, V], (El, KIn, VIn, M, Out), (ServerHeaderMatchInput :: El, K :: KIn, Set[V] :: VIn, M, Out)]
 
   implicit def getTransformer[MT <: MediaType, A] = at[GetElement[MT, A], Unit, (HNil, HNil, HNil, GetCall, FieldType[MT, A])]
 

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -35,7 +35,9 @@ object ApiDefinitionSpec {
   testCompile(Headers add[Int](fooW) add[Int](barW))[HeaderParam[barW.T, Int] :: HeaderParam[fooW.T, Int] :: HNil]
   testCompile(Headers add(fooW, testW))[FixedHeaderElement[fooW.T, testW.T] :: HNil]
   testCompile(Headers client(fooW, testW))[ClientHeaderElement[fooW.T, testW.T] :: HNil]
-  testCompile(Headers server(fooW, testW))[ServerHeaderElement[fooW.T, testW.T] :: HNil]
+  testCompile(Headers client[String](fooW))[ClientHeaderParam[fooW.T, String] :: HNil]
+  testCompile(Headers serverSend(fooW, testW))[ServerHeaderSendElement[fooW.T, testW.T] :: HNil]
+  testCompile(Headers serverMatch[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: HNil]
 
   // methods
   testCompile(api(Get[Json, Foo]))[GetElement[`Application/json`, Foo] :: HNil]

--- a/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
+++ b/shared/src/test/scala/typedapi/dsl/ApiDslSpec.scala
@@ -62,7 +62,8 @@ object ApiDslSpec {
   testCompile(_baseH :> Header(fooW, testW) :> Header[Int](fooW))[HeaderParam[fooW.T, Int] :: FixedHeaderElement[fooW.T, testW.T] :: _BaseH]
   testCompile(_baseH :> Client.Header[String](fooW))[ClientHeaderParam[fooW.T, String] :: _BaseH]
   testCompile(_baseH :> Client.Header(fooW, testW))[ClientHeaderElement[fooW.T, testW.T] :: _BaseH]
-  testCompile(_baseH :> Server.Header(fooW, testW))[ServerHeaderElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Server.Send(fooW, testW))[ServerHeaderSendElement[fooW.T, testW.T] :: _BaseH]
+  testCompile(_baseH :> Server.Match[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: _BaseH]
   testCompile(_baseH :> Get[Json, Foo])[GetElement[`Application/json`, Foo] :: _BaseH]
 
   // request body: add put or post

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -30,7 +30,8 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderParam[fooW.T, String] :: HNil, (ClientHeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderElement[fooW.T, barW.T] :: HNil, (ClientHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
-  testCompile[GetElement[Json, Foo] :: ServerHeaderElement[fooW.T, barW.T] :: HNil, (ServerHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ServerHeaderMatchParam[fooW.T, String] :: HNil, (ServerHeaderMatchInput :: HNil, fooW.T :: HNil, Set[String] :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ServerHeaderSendElement[fooW.T, barW.T] :: HNil, (ServerHeaderSend[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[
     GetElement[Json, Foo] :: HeaderParam[fooW.T, Boolean] :: QueryParam[fooW.T, Int] :: SegmentParam[fooW.T, String] :: PathElement[pathW.T] :: HNil, 


### PR DESCRIPTION
As proposed in #28 I added a new header type for the server-side which extracts headers based on some common key string pattern:

```Scala
val Api = := :> Server.Match[String]("Control-") :> Get[Json, User]

val endpoint = derive[IO](Api).from { headers => ??? ) // headers is of type Set[String]
```
All header keys which contain the pattern are extracted.