### PR TITLE
Improve ammonite support

### DIFF
--- a/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
+++ b/akka-http-client/src/main/scala/typedapi/client/akkahttp/package.scala
@@ -27,16 +27,25 @@ package object akkahttp {
         response.toStrict(bodyConsumerTimeout)
       }
 
-  def getRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
-                                                                  ec: ExecutionContext, 
-                                                                  mat: Materializer) = new GetRequest[HttpExt, Future, A] {
+  def rawGetRequest(bodyConsumerTimeout: FiniteDuration)(implicit ec: ExecutionContext, 
+                                                                  mat: Materializer) = new RawGetRequest[HttpExt, Future] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.GET)
 
       execRequest(cm.client, request, bodyConsumerTimeout)
     }
+  }
+
+  implicit def rawGetRequestImpl(implicit bodyConsumerTimeout: FiniteDuration,
+                                          ec: ExecutionContext,
+                                          mat: Materializer): RawGetRequest[HttpExt, Future] = rawGetRequest(bodyConsumerTimeout)
+
+  def getRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
+                                                                  ec: ExecutionContext, 
+                                                                  mat: Materializer) = new GetRequest[HttpExt, Future, A] {
+    private val raw = rawGetRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, cm).flatMap { response =>
@@ -44,22 +53,30 @@ package object akkahttp {
       }
   }
 
-
   implicit def getRequestImpl[A](implicit bodyConsumerTimeout: FiniteDuration,
                                           decoder: FromEntityUnmarshaller[A],
                                           ec: ExecutionContext,
                                           mat: Materializer): GetRequest[HttpExt, Future, A] = getRequest(bodyConsumerTimeout)
 
-  def putRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
-                                                                  ec: ExecutionContext, 
-                                                                  mat: Materializer) = new PutRequest[HttpExt, Future, A] {
+  def rawPutRequest(bodyConsumerTimeout: FiniteDuration)(implicit ec: ExecutionContext, 
+                                                                  mat: Materializer) = new RawPutRequest[HttpExt, Future] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.PUT)
 
       execRequest(cm.client, request, bodyConsumerTimeout)
     }
+  }
+
+  implicit def rawPutRequestImpl(implicit bodyConsumerTimeout: FiniteDuration,
+                                          ec: ExecutionContext,
+                                          mat: Materializer): RawPutRequest[HttpExt, Future] = rawPutRequest(bodyConsumerTimeout)
+
+  def putRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
+                                                                  ec: ExecutionContext, 
+                                                                  mat: Materializer) = new PutRequest[HttpExt, Future, A] {
+    private val raw = rawPutRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, cm).flatMap { response =>
@@ -72,19 +89,30 @@ package object akkahttp {
                                           ec: ExecutionContext,
                                           mat: Materializer): PutRequest[HttpExt, Future, A] = putRequest(bodyConsumerTimeout)
 
-  def putBodyRequest[Bd, A](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
-                                                                          decoder: FromEntityUnmarshaller[A],
+  def rawPutBodyRequest[Bd](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
                                                                           ec: ExecutionContext, 
-                                                                          mat: Materializer) = new PutWithBodyRequest[HttpExt, Future, Bd, A] {
+                                                                          mat: Materializer) = new RawPutWithBodyRequest[HttpExt, Future, Bd] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
         val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.PUT, entity = marshalledBody)
 
         execRequest(cm.client, request, bodyConsumerTimeout)
       }
     }
+  }
+
+  implicit def rawPutBodyRequestImpl[Bd](implicit bodyConsumerTimeout: FiniteDuration,
+                                                  encoder: ToEntityMarshaller[Bd],
+                                                  ec: ExecutionContext,
+                                                  mat: Materializer): RawPutWithBodyRequest[HttpExt, Future, Bd] = rawPutBodyRequest(bodyConsumerTimeout)
+
+  def putBodyRequest[Bd, A](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
+                                                                          decoder: FromEntityUnmarshaller[A],
+                                                                          ec: ExecutionContext, 
+                                                                          mat: Materializer) = new PutWithBodyRequest[HttpExt, Future, Bd, A] {
+    private val raw = rawPutBodyRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, body, cm).flatMap { response =>
@@ -98,16 +126,25 @@ package object akkahttp {
                                                   ec: ExecutionContext,
                                                   mat: Materializer): PutWithBodyRequest[HttpExt, Future, Bd, A] = putBodyRequest(bodyConsumerTimeout)
 
-  def postRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
-                                                                   ec: ExecutionContext, 
-                                                                   mat: Materializer) = new PostRequest[HttpExt, Future, A] {
+  def rawPostRequest(bodyConsumerTimeout: FiniteDuration)(implicit ec: ExecutionContext, 
+                                                                   mat: Materializer) = new RawPostRequest[HttpExt, Future] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.POST)
 
       execRequest(cm.client, request, bodyConsumerTimeout)
     }
+  }
+
+  implicit def rawPostRequestImpl(implicit bodyConsumerTimeout: FiniteDuration,
+                                           ec: ExecutionContext,
+                                           mat: Materializer): RawPostRequest[HttpExt, Future] = rawPostRequest(bodyConsumerTimeout)
+
+  def postRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
+                                                                   ec: ExecutionContext, 
+                                                                   mat: Materializer) = new PostRequest[HttpExt, Future, A] {
+    private val raw = rawPostRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, cm).flatMap { response =>
@@ -120,19 +157,30 @@ package object akkahttp {
                                            ec: ExecutionContext,
                                            mat: Materializer): PostRequest[HttpExt, Future, A] = postRequest(bodyConsumerTimeout)
 
-  def postBodyRequest[Bd, A](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
-                                                                           decoder: FromEntityUnmarshaller[A],
+  def rawPostBodyRequest[Bd](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
                                                                            ec: ExecutionContext, 
-                                                                           mat: Materializer) = new PostWithBodyRequest[HttpExt, Future, Bd, A] {
+                                                                           mat: Materializer) = new RawPostWithBodyRequest[HttpExt, Future, Bd] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[Resp] = {
       Marshal(body).to[RequestEntity].flatMap { marshalledBody =>
         val request = mkRequest(deriveUriString(cm, uri), queries, headers - "Content-Type").copy(HttpMethods.POST, entity = marshalledBody)
 
         execRequest(cm.client, request, bodyConsumerTimeout)
       }
     }
+  }
+
+  implicit def rawPostBodyRequestImpl[Bd](implicit bodyConsumerTimeout: FiniteDuration,
+                                                   encoder: ToEntityMarshaller[Bd],
+                                                   ec: ExecutionContext,
+                                                   mat: Materializer): RawPostWithBodyRequest[HttpExt, Future, Bd] = rawPostBodyRequest(bodyConsumerTimeout)
+
+  def postBodyRequest[Bd, A](bodyConsumerTimeout: FiniteDuration)(implicit encoder: ToEntityMarshaller[Bd],
+                                                                           decoder: FromEntityUnmarshaller[A],
+                                                                           ec: ExecutionContext, 
+                                                                           mat: Materializer) = new PostWithBodyRequest[HttpExt, Future, Bd, A] {
+    private val raw = rawPostBodyRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, body, cm).flatMap { response =>
@@ -146,16 +194,25 @@ package object akkahttp {
                                                    ec: ExecutionContext,
                                                    mat: Materializer): PostWithBodyRequest[HttpExt, Future, Bd, A] = postBodyRequest(bodyConsumerTimeout)
 
-  def deleteRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
-                                                                     ec: ExecutionContext, 
-                                                                     mat: Materializer) = new DeleteRequest[HttpExt, Future, A] {
+  def rawDeleteRequest(bodyConsumerTimeout: FiniteDuration)(implicit ec: ExecutionContext, 
+                                                                     mat: Materializer) = new RawDeleteRequest[HttpExt, Future] {
     type Resp = HttpResponse
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[Resp] = {
       val request = mkRequest(deriveUriString(cm, uri), queries, headers).copy(HttpMethods.DELETE)
 
       execRequest(cm.client, request, bodyConsumerTimeout)
     }
+  }
+
+  implicit def rawDeleteRequestImpl(implicit bodyConsumerTimeout: FiniteDuration,
+                                             ec: ExecutionContext,
+                                             mat: Materializer): RawDeleteRequest[HttpExt, Future] = rawDeleteRequest(bodyConsumerTimeout)
+
+  def deleteRequest[A](bodyConsumerTimeout: FiniteDuration)(implicit decoder: FromEntityUnmarshaller[A],
+                                                                     ec: ExecutionContext, 
+                                                                     mat: Materializer) = new DeleteRequest[HttpExt, Future, A] {
+    private val raw = rawDeleteRequest(bodyConsumerTimeout)
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[HttpExt]): Future[A] =
       raw(uri, queries, headers, cm).flatMap { response =>

--- a/ammonite-client-support/src/main/scala/typedapi/client/package.scala
+++ b/ammonite-client-support/src/main/scala/typedapi/client/package.scala
@@ -1,0 +1,30 @@
+package typedapi.client
+
+import typedapi.util._
+import scalaj.http._
+
+package object amm {
+
+  type Id[A]       = scalajhttp.Id[A]
+  type Blocking[A] = scalajhttp.Blocking[A]
+
+  def clientManager(host: String, port: Int): ClientManager[Http.type] = ClientManager(Http, host, port)
+
+  implicit def rawGetRequestAmm = scalajhttp.rawGetRequest
+  implicit def getRequestAmm[A](implicit decoder: Decoder[Id, A]) = scalajhttp.getRequest[A]
+
+  implicit def rawPutRequestAmm = scalajhttp.rawPutRequest
+  implicit def putRequestAmm[A](implicit decoder: Decoder[Id, A]) = scalajhttp.putRequest[A]
+
+  implicit def rawPutBodyRequestAmm[Bd](implicit encoder: Encoder[Id, Bd]) = scalajhttp.rawPutBodyRequest[Bd]
+  implicit def putBodyRequestAmm[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = scalajhttp.putBodyRequest[Bd, A]
+
+  implicit def rawPostRequestAmm = scalajhttp.rawPostRequest
+  implicit def postRequest[A](implicit decoder: Decoder[Id, A]) = scalajhttp.postRequest[A]
+
+  implicit def rawPostBodyRequestAm[Bd](implicit encoder: Encoder[Id, Bd]) = scalajhttp.rawPostBodyRequest[Bd]
+  implicit def postBodyRequestAmm[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = scalajhttp.postBodyRequest[Bd, A]
+
+  implicit def rawDeleteRequestAmm = scalajhttp.rawDeleteRequest
+  implicit def deleteRequestAmm[A](implicit decoder: Decoder[Id, A]) = scalajhttp.deleteRequest[A]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,8 @@ lazy val typedapi = project
     `akka-http-server`,
     `js-client`,
     `scalaj-http-client`,
-    `http-support-tests`
+    `http-support-tests`,
+    `ammonite-client-support`
   )
 
 lazy val shared = crossProject.crossType(CrossType.Pure)
@@ -213,3 +214,13 @@ lazy val `http-support-tests` = project
     libraryDependencies ++= Dependencies.httpSupportTests
   )
   .dependsOn(`http4s-client`, `http4s-server`, `akka-http-client`, `akka-http-server`, `scalaj-http-client`)
+
+lazy val `ammonite-client-support` = project
+  .in(file("ammonite-client-support"))
+  .settings(
+    commonSettings,
+    mavenSettings,
+    name := "typedapi-ammonite-client",
+    libraryDependencies ++= Dependencies.ammoniteSupport
+  )
+  .dependsOn(`scalaj-http-client`)

--- a/client/src/main/scala/typedapi/client/ApiRequest.scala
+++ b/client/src/main/scala/typedapi/client/ApiRequest.scala
@@ -8,55 +8,78 @@ import scala.language.higherKinds
 import scala.annotation.implicitNotFound
 
 /** Basic api request element. Provides a function to create an effect representing the actual request. */
-@implicitNotFound("""Cannot find ApiRequest instance for {{M}}. Do you miss some implicit value e.g. encoders/decoders?
+@implicitNotFound("""Cannot find RawApiRequest instance for ${M}.
+
+context: ${F}""")
+trait RawApiRequest[M <: MethodType, D <: HList, C, F[_]] {
+
+  type Resp
+
+  def apply(data: D, cm: ClientManager[C]): F[Resp]
+}
+
+@implicitNotFound("""Cannot find ApiRequest instance for ${M}. Do you miss some implicit value e.g. encoders/decoders?
 
 ouput: ${Out}
 context: ${F}""")
 trait ApiRequest[M <: MethodType, D <: HList, C, F[_], Out] {
 
-  type Resp
-
-  def raw(data: D, cm: ClientManager[C]): F[Resp]
   def apply(data: D, cm: ClientManager[C]): F[Out]
 }
 
-trait ApiWithoutBodyRequest[M <: MethodType, C, F[_], Out] extends ApiRequest[M, Data, C, F, Out] {
+trait RawApiWithoutBodyRequest[M <: MethodType, C, F[_]] extends RawApiRequest[M, Data, C, F] {
 
-  def raw(data: Data, cm: ClientManager[C]): F[Resp] = {
+  def apply(data: Data, cm: ClientManager[C]): F[Resp] = {
     val (uri :: queries :: headers :: HNil): Data = data
 
-    raw(uri, queries, headers, cm)
+    apply(uri, queries, headers, cm)
   }
-  def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[C]): F[Resp]
+
+  def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[C]): F[Resp]
+}
+
+trait ApiWithoutBodyRequest[M <: MethodType, C, F[_], Out] extends ApiRequest[M, Data, C, F, Out] {
 
   def apply(data: Data, cm: ClientManager[C]): F[Out] = {
     val (uri :: queries :: headers :: HNil): Data = data
 
     apply(uri, queries, headers, cm)
   }
+
   def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[C]): F[Out]
 }
 
-trait ApiWithBodyRequest[M <: MethodType, C, F[_], Bd, Out] extends ApiRequest[M, DataWithBody[Bd], C, F, Out] {
+trait RawApiWithBodyRequest[M <: MethodType, C, F[_], Bd] extends RawApiRequest[M, DataWithBody[Bd], C, F] {
 
-  def raw(data: DataWithBody[Bd], cm: ClientManager[C]): F[Resp] = {
+  def apply(data: DataWithBody[Bd], cm: ClientManager[C]): F[Resp] = {
     val (uri :: queries :: headers :: body :: HNil): DataWithBody[Bd] = data
 
-    raw(uri, queries, headers, body, cm)
+    apply(uri, queries, headers, body, cm)
   }
-  def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[C]): F[Resp]
+
+  def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[C]): F[Resp]
+}
+
+trait ApiWithBodyRequest[M <: MethodType, C, F[_], Bd, Out] extends ApiRequest[M, DataWithBody[Bd], C, F, Out] {
 
   def apply(data: DataWithBody[Bd], cm: ClientManager[C]): F[Out] = {
     val (uri :: queries :: headers :: body :: HNil): DataWithBody[Bd] = data
 
     apply(uri, queries, headers, body, cm)
   }
+
   def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[C]): F[Out]
 }
 
+trait RawGetRequest[C, F[_]] extends RawApiWithoutBodyRequest[GetCall, C, F]
 trait GetRequest[C, F[_], A] extends ApiWithoutBodyRequest[GetCall, C, F, A]
+trait RawPutRequest[C, F[_]] extends RawApiWithoutBodyRequest[PutCall, C, F]
 trait PutRequest[C, F[_], A] extends ApiWithoutBodyRequest[PutCall, C, F, A]
+trait RawPutWithBodyRequest[C, F[_], Bd] extends RawApiWithBodyRequest[PutWithBodyCall, C, F, Bd]
 trait PutWithBodyRequest[C, F[_], Bd, A] extends ApiWithBodyRequest[PutWithBodyCall, C, F, Bd, A]
+trait RawPostRequest[C, F[_]] extends RawApiWithoutBodyRequest[PostCall, C, F]
 trait PostRequest[C, F[_], A] extends ApiWithoutBodyRequest[PostCall, C, F, A]
+trait RawPostWithBodyRequest[C, F[_], Bd] extends RawApiWithBodyRequest[PostWithBodyCall, C, F, Bd]
 trait PostWithBodyRequest[C, F[_], Bd, A] extends ApiWithBodyRequest[PostWithBodyCall, C, F, Bd, A]
+trait RawDeleteRequest[C, F[_]] extends RawApiWithoutBodyRequest[DeleteCall, C, F]
 trait DeleteRequest[C, F[_], A] extends ApiWithoutBodyRequest[DeleteCall, C, F, A]

--- a/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
+++ b/client/src/main/scala/typedapi/client/ExecutableDerivation.scala
@@ -18,10 +18,10 @@ final class ExecutableDerivation[El <: HList, KIn <: HList, VIn <: HList, M <: M
       req(data, cm)
     }
 
-    def raw[C](cm: ClientManager[C])(implicit req: ApiRequest[M, D, C, F, O]): F[req.Resp] = {
+    def raw[C](cm: ClientManager[C])(implicit req: RawApiRequest[M, D, C, F]): F[req.Resp] = {
       val data = builder(input, List.newBuilder, Map.empty, Map.empty)
 
-      req.raw(data, cm)
+      req(data, cm)
     }
   }
 

--- a/client/src/main/scala/typedapi/client/test/package.scala
+++ b/client/src/main/scala/typedapi/client/test/package.scala
@@ -8,45 +8,73 @@ package object test {
 
   val clientManager: TestClientM = ClientManager((), "", 0)
 
-  def testGet[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new GetRequest[Unit, F, A] {
+  def testRawGet[F[_]](pure: ReqInput => F[ReqInput]) = new RawGetRequest[Unit, F] {
     type Resp = ReqInput
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("GET", uri, queries, headers))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("GET", uri, queries, headers))
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = 
+      pure(ReqInput("GET", uri, queries, headers))
+  }
+  def testGet[F[_], A](f: ReqInput => F[A]) = new GetRequest[Unit, F, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = 
+      f(ReqInput("GET", uri, queries, headers))
   }
 
-  def testPut[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new PutRequest[Unit, F, A] {
+  def testRawPut[F[_]](pure: ReqInput => F[ReqInput]) = new RawPutRequest[Unit, F] {
     type Resp = ReqInput
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("PUT", uri, queries, headers))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("PUT", uri, queries, headers))
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = 
+      pure(ReqInput("PUT", uri, queries, headers))
+  }
+  def testPut[F[_], A](f: ReqInput => F[A]) = new PutRequest[Unit, F, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = 
+      f(ReqInput("PUT", uri, queries, headers))
   }
 
-  def testPutWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A])(pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = new PutWithBodyRequest[Unit, F, Bd, A] {
+  def testRawPutWithBody[F[_], Bd](pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = 
+    new RawPutWithBodyRequest[Unit, F, Bd] {
+      type Resp = ReqInputWithBody[Bd]
+
+      def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = 
+        pure(ReqInputWithBody("PUT", uri, queries, headers, body))
+    }
+  def testPutWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A]) = 
+    new PutWithBodyRequest[Unit, F, Bd, A] {
+      def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = 
+        f(ReqInputWithBody("PUT", uri, queries, headers, body))
+    }
+
+  def testRawPost[F[_]](pure: ReqInput => F[ReqInput]) = new RawPostRequest[Unit, F] {
+    type Resp = ReqInput
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = 
+      pure(ReqInput("POST", uri, queries, headers))
+  }
+  def testPost[F[_], A](f: ReqInput => F[A]) = new PostRequest[Unit, F, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = 
+      f(ReqInput("POST", uri, queries, headers))
+  }
+
+  def testRawPostWithBody[F[_], Bd](pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = 
+    new RawPostWithBodyRequest[Unit, F, Bd] {
     type Resp = ReqInputWithBody[Bd]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = pure(ReqInputWithBody("PUT", uri, queries, headers, body))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = f(ReqInputWithBody("PUT", uri, queries, headers, body))
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = 
+      pure(ReqInputWithBody("POST", uri, queries, headers, body))
   }
+  def testPostWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A]) = 
+    new PostWithBodyRequest[Unit, F, Bd, A] {
+      def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = 
+        f(ReqInputWithBody("POST", uri, queries, headers, body))
+    }
 
-  def testPost[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new PostRequest[Unit, F, A] {
+  def testRawDelete[F[_]](pure: ReqInput => F[ReqInput]) = new RawDeleteRequest[Unit, F] {
     type Resp = ReqInput
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("POST", uri, queries, headers))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("POST", uri, queries, headers))
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = 
+      pure(ReqInput("DELETE", uri, queries, headers))
   }
-
-  def testPostWithBody[F[_], Bd, A](f: ReqInputWithBody[Bd] => F[A])(pure: ReqInputWithBody[Bd] => F[ReqInputWithBody[Bd]]) = new PostWithBodyRequest[Unit, F, Bd, A] {
-    type Resp = ReqInputWithBody[Bd]
-
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[Resp] = pure(ReqInputWithBody("POST", uri, queries, headers, body))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: TestClientM): F[A] = f(ReqInputWithBody("POST", uri, queries, headers, body))
-  }
-
-  def testDelete[F[_], A](f: ReqInput => F[A])(pure: ReqInput => F[ReqInput]) = new DeleteRequest[Unit, F, A] {
-    type Resp = ReqInput
-
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[Resp] = pure(ReqInput("DELETE", uri, queries, headers))
-    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = f(ReqInput("DELETE", uri, queries, headers))
+  def testDelete[F[_], A](f: ReqInput => F[A]) = new DeleteRequest[Unit, F, A] {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: TestClientM): F[A] = 
+      f(ReqInput("DELETE", uri, queries, headers))
   }
 }

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -12,12 +12,12 @@ final class RequestDataBuilderSpec extends Specification {
 
   type Result = (String, List[String], Map[String, String], Map[String, String], Option[Foo])
 
-  implicit val get       = testGet[Id, ReqInput](identity)(identity)
-  implicit val put       = testPut[Id, ReqInput](identity)(identity)
-  implicit def putB[Bd]  = testPutWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)(identity)
-  implicit val post      = testPost[Id, ReqInput](identity)(identity)
-  implicit def postB[Bd] = testPostWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)(identity)
-  implicit val delete    = testDelete[Id, ReqInput](identity)(identity)
+  implicit val get       = testGet[Id, ReqInput](identity)
+  implicit val put       = testPut[Id, ReqInput](identity)
+  implicit def putB[Bd]  = testPutWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)
+  implicit val post      = testPost[Id, ReqInput](identity)
+  implicit def postB[Bd] = testPostWithBody[Id, Bd, ReqInputWithBody[Bd]](identity)
+  implicit val delete    = testDelete[Id, ReqInput](identity)
 
   "executes compiled api" >> {
     val cm = clientManager
@@ -77,13 +77,20 @@ final class RequestDataBuilderSpec extends Specification {
 
       "request body" >> {
         val api0 = derive(:= :> ReqBody[Json, Int] :> Put[Json, ReqInputWithBody[Int]])
-        api0(0).run[Id](cm)(putB) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json")), 0)
+        api0(0).run[Id](cm) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json")), 0)
       }
 
       "path" >> {
         val api0 = derive(:= :> "hello" :> "world" :> Get[Json, ReqInput])
         api0().run[Id](cm) === ReqInput("GET", "hello" :: "world" :: Nil, Map(), Map(("Accept", "application/json")))
       }
+    }
+
+    "raw" >> {
+      implicit def rawPutB[Bd] = testRawPutWithBody[Id, Bd](identity)
+
+      val api0 = derive(:= :> ReqBody[Json, Int] :> Put[Json, ReqInputWithBody[Int]])
+      api0(0).run[Id].raw(cm) === ReqInputWithBody("PUT", Nil, Map(), Map(("Accept", "application/json")), 0)
     }
 
     "composition" >> {

--- a/docs/example/ammonite_client_example.sc
+++ b/docs/example/ammonite_client_example.sc
@@ -1,0 +1,15 @@
+import $ivy.`com.github.pheymann::typedapi-ammonite-client:0.2.0-M1`
+
+import typedapi._
+import client._
+import amm._
+
+val cm = clientManager("http://localhost", 9000)
+
+final case class User(name: String, age: Int)
+
+val Api = api(Get[Json, User], Root, headers = Headers.serverSend("Access-Control-Allow-Origin", "*"))
+
+val get = derive(Api)
+
+val response = get().run[Id].raw(cm)

--- a/docs/example/build.sbt
+++ b/docs/example/build.sbt
@@ -1,5 +1,5 @@
 
-val typedapiVersion = "0.1.0"
+val typedapiVersion = "0.2.0-M1"
 val http4sVersion   = "0.18.0"
 
 val commonSettings = Seq(

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -57,7 +57,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
     }
 
     "raw" >> {
-      m0().run[Blocking].raw(cm).right.map(_.body) === Right("""{"name":"foo","age":27}""")
+      m0().run[Id].raw(cm).body === """{"name":"foo","age":27}"""
     }
 
     step {

--- a/http4s-client/src/main/scala/typedapi/client/http4s/package.scala
+++ b/http4s-client/src/main/scala/typedapi/client/http4s/package.scala
@@ -1,10 +1,9 @@
 package typedapi.client
 
-import cats.{MonadError, Applicative}
+import cats.{Monad, MonadError, Applicative}
 import org.http4s._
 import org.http4s.client._
 import org.http4s.Status.Successful
-import org.http4s.headers.{Accept, MediaRangeAndQValue}
 
 import scala.language.higherKinds
 
@@ -31,16 +30,8 @@ package object http4s {
       else req
     }
 
-    def run[A](cm: ClientManager[Client[F]])(implicit d: EntityDecoder[F, A], F: Applicative[F]): F[Response[F]] = {
-      val r = 
-        if (d.consumes.nonEmpty) {
-          val m = d.consumes.toList
-          req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
-        } 
-        else req
-
-      cm.client.fetch(r)(resp => F.pure(resp))
-    }
+    def run(cm: ClientManager[Client[F]])(implicit F: Applicative[F]): F[Response[F]] =
+      cm.client.fetch(req)(resp => F.pure(resp))
   }
 
   private implicit class Http4sResponseOps[F[_]](resp: Response[F]) {
@@ -53,97 +44,122 @@ package object http4s {
     }
   }
 
-  implicit def getRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new GetRequest[Client[F], F, A] {
+  implicit def rawGetRequest[F[_]](implicit F: Applicative[F]) = new RawGetRequest[Client[F], F] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.GET, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      request.run[A](cm)
+      request.run(cm)
     }
+  }
+
+  implicit def getRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new GetRequest[Client[F], F, A] {
+    private val raw = rawGetRequest[F]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
-  implicit def putRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PutRequest[Client[F], F, A] {
+  implicit def rawPutRequest[F[_]](implicit F: Applicative[F]) = new RawPutRequest[Client[F], F] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.PUT, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      request.run[A](cm)
+      request.run(cm)
     }
+  }
+
+  implicit def putRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PutRequest[Client[F], F, A] {
+    private val raw = rawPutRequest[F]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
-  implicit def putBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
-                                                    decoder: EntityDecoder[F, A], 
-                                                    F: MonadError[F, Throwable]) = new PutWithBodyRequest[Client[F], F, Bd, A] {
+  implicit def rawPutBodyRequest[F[_], Bd](implicit encoder: EntityEncoder[F, Bd], F: Monad[F]) = new RawPutWithBodyRequest[Client[F], F, Bd] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
       val requestF = Request[F](Method.PUT, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
         .withBody(body)
 
-      F.flatMap(requestF)(_.run[A](cm))
+      F.flatMap(requestF)(_.run(cm))
     }
+  }
+
+  implicit def putBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
+                                                    decoder: EntityDecoder[F, A], 
+                                                    F: MonadError[F, Throwable]) = new PutWithBodyRequest[Client[F], F, Bd, A] {
+    private val raw = rawPutBodyRequest[F, Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, body, cm))(_.decode[A])
   }
 
-  implicit def postRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PostRequest[Client[F], F, A] {
+  implicit def rawPostRequest[F[_]](implicit F: Applicative[F]) = new RawPostRequest[Client[F], F] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.POST, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      request.run[A](cm)
+      request.run(cm)
     }
+  }
+
+  implicit def postRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new PostRequest[Client[F], F, A] {
+    private val raw = rawPostRequest[F]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])
   }
 
-  implicit def postBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
-                                                     decoder: EntityDecoder[F, A], 
-                                                     F: MonadError[F, Throwable]) = new PostWithBodyRequest[Client[F], F, Bd, A] {
+  implicit def rawPostBodyRequest[F[_], Bd](implicit encoder: EntityEncoder[F, Bd], 
+                                                     F: Monad[F]) = new RawPostWithBodyRequest[Client[F], F, Bd] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[Resp] = {
       val requestF = Request[F](Method.POST, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
         .withBody(body)
 
-      F.flatMap(requestF)(_.run[A](cm))
+      F.flatMap(requestF)(_.run(cm))
     }
+  }
+
+  implicit def postBodyRequest[F[_], Bd, A](implicit encoder: EntityEncoder[F, Bd], 
+                                                     decoder: EntityDecoder[F, A], 
+                                                     F: MonadError[F, Throwable]) = new PostWithBodyRequest[Client[F], F, Bd, A] {
+    private val raw = rawPostBodyRequest[F, Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, body, cm))(_.decode[A])
   }
 
-  implicit def deleteRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new DeleteRequest[Client[F], F, A] {
+  implicit def rawDeleteRequest[F[_]](implicit F: Applicative[F]) = new RawDeleteRequest[Client[F], F] {
     type Resp = Response[F]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[Resp] = {
       val request = Request[F](Method.DELETE, Uri.unsafeFromString(deriveUriString(cm, uri)))
         .withQuery(queries)
         .withHeaders(headers)
 
-      request.run[A](cm)
+      request.run(cm)
     }
+  }
+
+  implicit def deleteRequest[F[_], A](implicit decoder: EntityDecoder[F, A], F: MonadError[F, Throwable]) = new DeleteRequest[Client[F], F, A] {
+    private val raw = rawDeleteRequest[F]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Client[F]]): F[A] =
       F.flatMap(raw(uri, queries, headers, cm))(_.decode[A])

--- a/js-client/src/main/scala/typedapi/client/js/package.scala
+++ b/js-client/src/main/scala/typedapi/client/js/package.scala
@@ -21,38 +21,46 @@ package object js {
     case Left(error) => Future.failed(error)
   }
 
-  implicit def getRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new GetRequest[Ajax.type, Future, A] {
+  implicit def rawGetRequest(implicit ec: ExecutionContext) = new RawGetRequest[Ajax.type, Future] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .get(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
+  }
+
+  implicit def getRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new GetRequest[Ajax.type, Future, A] {
+    private val raw = rawGetRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
-  implicit def putRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PutRequest[Ajax.type, Future, A] {
+  implicit def rawPutRequest(implicit ec: ExecutionContext) = new RawPutRequest[Ajax.type, Future] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .put(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
+  }
+
+  implicit def putRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PutRequest[Ajax.type, Future, A] {
+    private val raw = rawPutRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
-  implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PutWithBodyRequest[Ajax.type, Future, Bd, A] {
+  implicit def rawPutBodyRequest[Bd](implicit encoder: Encoder[Future, Bd], ec: ExecutionContext) = new RawPutWithBodyRequest[Ajax.type, Future, Bd] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
       encoder(body).flatMap { encoded => 
         cm.client
           .put(
@@ -61,29 +69,37 @@ package object js {
             data    = encoded
           )
       }
+  }
+
+  implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PutWithBodyRequest[Ajax.type, Future, Bd, A] {
+    private val raw = rawPutBodyRequest[Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, body, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
-  implicit def postRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PostRequest[Ajax.type, Future, A] {
+  implicit def rawPostRequest(implicit ec: ExecutionContext) = new RawPostRequest[Ajax.type, Future] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .post(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
+  }
+
+  implicit def postRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new PostRequest[Ajax.type, Future, A] {
+    private val raw = rawPostRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
-  implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PostWithBodyRequest[Ajax.type, Future, Bd, A] {
+  implicit def rawPostBodyRequest[Bd](implicit encoder: Encoder[Future, Bd], ec: ExecutionContext) = new RawPostWithBodyRequest[Ajax.type, Future, Bd] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[Resp] =
       encoder(body).flatMap { encoded =>
         cm.client
           .post(
@@ -92,20 +108,28 @@ package object js {
             data    = encoded
           )
       }
+  }
+
+  implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Future, Bd], decoder: Decoder[Future, A], ec: ExecutionContext) = new PostWithBodyRequest[Ajax.type, Future, Bd, A] {
+    private val raw = rawPostBodyRequest[Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, body, cm).flatMap(response => flatten(decoder(response.responseText)))
   }
 
-  implicit def deleteRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new DeleteRequest[Ajax.type, Future, A] {
+  implicit def rawDeleteRequest(implicit ec: ExecutionContext) = new RawDeleteRequest[Ajax.type, Future] {
     type Resp = XMLHttpRequest
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[Resp] =
       cm.client
         .delete(
           url     = deriveUriString(cm, uri) + renderQueries(queries),
           headers = headers
         )
+  }
+
+  implicit def deleteRequest[A](implicit decoder: Decoder[Future, A], ec: ExecutionContext) = new DeleteRequest[Ajax.type, Future, A] {
+    private val raw = rawDeleteRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Ajax.type]): Future[A] =
       raw(uri, queries, headers, cm).flatMap(response => flatten(decoder(response.responseText)))

--- a/project/build.scala
+++ b/project/build.scala
@@ -66,4 +66,8 @@ object Dependencies {
 
     "org.specs2" %% "specs2-core" % specs2V         % Test
   )
+
+  val ammoniteSupport = Seq(
+    "org.scalaj" %% "scalaj-http" % scalajHttpV % Compile
+  )
 }

--- a/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
+++ b/scalaj-http-client/src/main/scala/typedapi/client/scalajhttp/package.scala
@@ -11,81 +11,105 @@ package object scalajhttp {
   private def reduceQueries(queries: Map[String, List[String]]): Map[String, String] = 
     queries.map { case (key, values) => key -> values.mkString(",") }(collection.breakOut)
 
-  implicit def getRequest[A](implicit decoder: Decoder[Id, A]) = new GetRequest[Http.type, Blocking, A] {
+  implicit def rawGetRequest = new RawGetRequest[Http.type, Id] {
     type Resp = HttpResponse[String]
 
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Id[Resp] = {
       val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("GET")
 
-      Right(req.asString)
+      req.asString
     }
+  }
+
+  implicit def getRequest[A](implicit decoder: Decoder[Id, A]) = new GetRequest[Http.type, Blocking, A] {
+    private val raw = rawGetRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, cm).body)
+  }
+
+  implicit def rawPutRequest = new RawPutRequest[Http.type, Id] {
+    type Resp = HttpResponse[String]
+    
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Id[Resp] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("PUT")
+
+      req.asString
+    }
   }
 
   implicit def putRequest[A](implicit decoder: Decoder[Id, A]) = new PutRequest[Http.type, Blocking, A] {
-    type Resp = HttpResponse[String]
-    
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
-      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("PUT")
-
-      Right(req.asString)
-    }
+    private val raw = rawPutRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, cm).body)
+  }
+
+  implicit def rawPutBodyRequest[Bd](implicit encoder: Encoder[Id, Bd]) = new RawPutWithBodyRequest[Http.type, Id, Bd] {
+    type Resp = HttpResponse[String]
+    
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Id[Resp] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).put(encoder(body))
+
+      req.asString
+    }
   }
 
   implicit def putBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PutWithBodyRequest[Http.type, Blocking, Bd, A] {
-    type Resp = HttpResponse[String]
-    
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[Resp] = {
-      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).put(encoder(body))
-
-      Right(req.asString)
-    }
+    private val raw = rawPutBodyRequest[Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, body, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, body, cm).body)
+  }
+
+  implicit def rawPostRequest = new RawPostRequest[Http.type, Id] {
+    type Resp = HttpResponse[String]
+    
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Id[Resp] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("POST")
+
+      req.asString
+    }
   }
 
   implicit def postRequest[A](implicit decoder: Decoder[Id, A]) = new PostRequest[Http.type, Blocking, A] {
-    type Resp = HttpResponse[String]
-    
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
-      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("POST")
-
-      Right(req.asString)
-    }
+    private val raw = rawPostRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, cm).body)
+  }
+
+  implicit def rawPostBodyRequest[Bd](implicit encoder: Encoder[Id, Bd]) = new RawPostWithBodyRequest[Http.type, Id, Bd] {
+    type Resp = HttpResponse[String]
+    
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Id[Resp] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).postData(encoder(body))
+
+      req.asString
+    }
   }
 
   implicit def postBodyRequest[Bd, A](implicit encoder: Encoder[Id, Bd], decoder: Decoder[Id, A]) = new PostWithBodyRequest[Http.type, Blocking, Bd, A] {
-    type Resp = HttpResponse[String]
-    
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[Resp] = {
-      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).postData(encoder(body))
-
-      Right(req.asString)
-    }
+    private val raw = rawPostBodyRequest[Bd]
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], body: Bd, cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, body, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, body, cm).body)
+  }
+
+  implicit def rawDeleteRequest = new RawDeleteRequest[Http.type, Id] {
+    type Resp = HttpResponse[String]
+
+    def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Id[Resp] = {
+      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("DELETE")
+
+      req.asString
+    }
   }
 
   implicit def deleteRequest[A](implicit decoder: Decoder[Id, A]) = new DeleteRequest[Http.type, Blocking, A] {
-    type Resp = HttpResponse[String]
-
-    def raw(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[Resp] = {
-      val req = cm.client(deriveUriString(cm, uri)).params(reduceQueries(queries)).headers(headers).method("DELETE")
-
-      Right(req.asString)
-    }
+    private val raw = rawDeleteRequest
 
     def apply(uri: List[String], queries: Map[String, List[String]], headers: Map[String, String], cm: ClientManager[Http.type]): Blocking[A] =
-      raw(uri, queries, headers, cm).right.flatMap(resp => decoder(resp.body))
+      decoder(raw(uri, queries, headers, cm).body)
   }
 }


### PR DESCRIPTION
Right now you have to do the following things to get a client in Ammonite:

```Scala
import $ivy.`com.github.pheymann::typedapi-scalaj-http-client:0.1.0`
import $ivy.`org.scalaj::scalaj-http:2.4.1`

import typedapi._
import client._
import util._
import scalajhttp._
import scalaj.http.Http

val Api = api(Get[Json, User], Root)

val get = derive(Api)
val cm = ClientManager(Http, "host", 80)

implicit val decoder = Decoder[Blocking](raw => ??? // to User)

val response = get().run[Blockling].raw(cm) // Right(HttpResponse...)
```

You have to create a `Decoder` as `ApiRequest` combines both raw and decoded action but retrieves the decoder at the construction level. Furthermore, you have to use the `Blocking[A]` effect which is `Either[Exception, A]` even though the result will always be a `Right`.

With this PR this code reduces to:

```Scala
import $ivy.`com.github.pheymann::typedapi-ammonite-client:0.2.0`

import typedapi._
import client._
import amm._

val Api = api(Get[Json, User], Root)

val get = derive(Api)
val cm = clientManager("host", 80)

val response = get().run[Id].raw(cm) // HttpResponse...
```

It is three imports less and you can access the response directly.