### PR TITLE
Server StatusCodes

### DIFF
--- a/docs/ServerCreation.md
+++ b/docs/ServerCreation.md
@@ -21,6 +21,41 @@ val endpoints = deriveAll[IO](Api).from(
 )
 ```
 
+### Set Status Codes
+#### Success
+```Scala
+deriveAll[IO](Api).from(
+  name =>
+      val user: User = ???
+      
+      success(user) // creates a 200
+  ...
+}
+```
+
+or
+
+```Scala
+deriveAll[IO](Api).from(
+  name =>
+      val user: User = ???
+      
+      successWith(Ok)(user) // set code
+  ...
+}
+```
+
+#### Error
+```Scala
+deriveAll[IO](Api).from(
+  name =>
+      val user: Option[User] = ???
+      
+      user.fold(errorWith(NotFound, s"no user $id")(user => success(user))
+  ...
+}
+```
+
 ### Http4s
 If you want to use [http4s](https://github.com/http4s/http4s) as your server backend you have to add the following code:
 

--- a/docs/example/build.sbt
+++ b/docs/example/build.sbt
@@ -1,5 +1,5 @@
 
-val typedapiVersion = "0.2.0-M1"
+val typedapiVersion = "0.2.0-RC2"
 val http4sVersion   = "0.18.0"
 
 val commonSettings = Seq(

--- a/docs/example/server/src/main/scala/Server.scala
+++ b/docs/example/server/src/main/scala/Server.scala
@@ -10,21 +10,21 @@ object Server {
   implicit val decoder = jsonOf[IO, User]
   implicit val encoder = jsonEncoderOf[IO, User]
 
-  val get: () => IO[User] = () => IO.pure(User("Joe", 42))
-  val put: () => IO[User] = get
-  val post: () => IO[User] = get
-  val delete: () => IO[User] = get
+  val get: () => IO[Result[User]] = () => IO.pure(success(User("Joe", 42)))
+  val put: () => IO[Result[User]] = get
+  val post: () => IO[Result[User]] = get
+  val delete: () => IO[Result[User]] = get
 
-  val path: () => IO[User] = get
+  val path: () => IO[Result[User]] = get
 
-  val putBody: User => IO[User] = user => IO.pure(user)
-  val segment: String => IO[User] = name => IO.pure(User(name, 42))
-  val search: String => IO[User] = segment
+  val putBody: User => IO[Result[User]] = user => IO.pure(success(user))
+  val segment: String => IO[Result[User]] = name => IO.pure(success(User(name, 42)))
+  val search: String => IO[Result[User]] = segment
 
-  val header: String => IO[User] = consumer => IO.pure(User("found: " + consumer, 42))
-  val fixed: () => IO[User] = get
-  val client: () => IO[User] = get
-  val matching: Set[String] => IO[User] = matches => IO.pure(User(matches.mkString(""), 42))
+  val header: String => IO[Result[User]] = consumer => IO.pure(success(User("found: " + consumer, 42)))
+  val fixed: () => IO[Result[User]] = get
+  val client: () => IO[Result[User]] = get
+  val matching: Set[String] => IO[Result[User]] = matches => IO.pure(success(User(matches.mkString(""), 42)))
 
   val endpoints = deriveAll[IO](FromDefinition.MyApi).from(get, put, post, delete, path, putBody, segment, search, header, fixed, client, matching)
 

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -27,7 +27,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Blocking](cm) === Right(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -27,7 +27,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, code200, code400, code500) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Blocking](cm) === Right(User("foo", 27))

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -19,5 +19,8 @@ package object tests {
     (:= :> "body" :> ReqBody[Json, User] :> Put[Json, User]) :|:
     (:= :> Post[Json, User]) :|:
     (:= :> "body" :> ReqBody[Json, User] :> Post[Json, User]) :|:
-    (:= :> Query[List[String]]('reasons) :> Delete[Json, User])
+    (:= :> Query[List[String]]('reasons) :> Delete[Json, User]) :|:
+    (:= :> "status" :> "200" :> Get[Plain, String]) :|:
+    (:= :> "status" :> "400" :> Get[Plain, String]) :|:
+    (:= :> "status" :> "500" :> Get[Plain, String])
 }

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,7 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete, code200, code400, code500)
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,7 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete)
+  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete, code200, code400, code500)
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -1,5 +1,6 @@
 package http.support.tests.server
 
+import typedapi.server.{Result, successWith, Ok}
 import http.support.tests.{User, UserCoding}
 import org.http4s._
 import org.http4s.dsl.io._
@@ -86,19 +87,19 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
     }
   }
 
-  val path: () => F[User] = () => Applicative[F].pure(User("joe", 27))
-  val segment: String => F[User] = name => Applicative[F].pure(User(name, 27))
-  val query: Int => F[User] = age => Applicative[F].pure(User("joe", age))
-  val header: Int => F[User] = age => Applicative[F].pure(User("joe", age))
-  val fixed: () => F[User] = () => Applicative[F].pure(User("joe", 27))
-  val matching: Set[String] => F[User] = matches => Applicative[F].pure(User(matches.mkString(""), 27))
-  val get: () => F[User] = () => Applicative[F].pure(User("joe", 27))
-  val put: () => F[User] = () => Applicative[F].pure(User("joe", 27))
-  val putB: User => F[User] = user => Applicative[F].pure(user)
-  val post: () => F[User] = () => Applicative[F].pure(User("joe", 27))
-  val postB: User => F[User] = user => Applicative[F].pure(user)
-  val delete: List[String] => F[User] = reasons => {
+  val path: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val segment: String => F[Result[User]] = name => Applicative[F].pure(successWith(Ok)(User(name, 27)))
+  val query: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
+  val header: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
+  val fixed: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val matching: Set[String] => F[Result[User]] = matches => Applicative[F].pure(successWith(Ok)(User(matches.mkString(""), 27)))
+  val get: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val put: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val putB: User => F[Result[User]] = user => Applicative[F].pure(successWith(Ok)(user))
+  val post: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val postB: User => F[Result[User]] = user => Applicative[F].pure(successWith(Ok)(user))
+  val delete: List[String] => F[Result[User]] = reasons => {
     println(reasons)
-    Applicative[F].pure(User("joe", 27))
+    Applicative[F].pure(successWith(Ok)(User("joe", 27)))
   }
 }

--- a/server/src/main/scala/typedapi/server/EndpointComposition.scala
+++ b/server/src/main/scala/typedapi/server/EndpointComposition.scala
@@ -49,8 +49,8 @@ trait PrecompileEndpointLowPrio {
     (implicit extractor: RouteExtractor.Aux[El, KIn, VIn, M, HNil, ROut],
               methodShow: MethodToString[M],
               serverHeaders: ServerHeaderExtractor[El],
-              vinToFn: FnFromProduct.Aux[VIn => F[Out], Fn],
-              fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Out]]],
+              vinToFn: FnFromProduct.Aux[VIn => F[Result[Out]], Fn],
+              fnToVIn: Lazy[FnToProduct.Aux[Fn, VIn => F[Result[Out]]]],
               next: PrecompileEndpoint[F, T]) =
     new PrecompileEndpoint[F, (El, KIn, VIn, M, FieldType[MT, Out]) :: T] {
       type Fns    = Fn :: next.Fns
@@ -60,7 +60,7 @@ trait PrecompileEndpointLowPrio {
         def apply(fn: Fn): Endpoint[El, KIn, VIn, M, ROut, F, Out] = new Endpoint[El, KIn, VIn, M, ROut, F, Out](methodShow.show, extractor, serverHeaders(Map.empty)) {
           private val fin = fnToVIn.value(fn)
 
-          def apply(in: VIn): F[Out] = fin(in)
+          def apply(in: VIn): F[Result[Out]] = fin(in)
         }
       }
 

--- a/server/src/main/scala/typedapi/server/EndpointExecutor.scala
+++ b/server/src/main/scala/typedapi/server/EndpointExecutor.scala
@@ -33,7 +33,7 @@ object EndpointExecutor {
 
 trait NoReqBodyExecutor[El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, F[_], FOut] extends EndpointExecutor[El, KIn, VIn, M, VIn, F, FOut] {
 
-  protected def execute(input: VIn, endpoint: Endpoint[El, KIn, VIn, M, VIn, F, FOut]): F[FOut] = 
+  protected def execute(input: VIn, endpoint: Endpoint[El, KIn, VIn, M, VIn, F, FOut]): F[Result[FOut]] = 
     endpoint.apply(input)
 }
 
@@ -42,6 +42,6 @@ trait ReqBodyExecutor[El <: HList, KIn <: HList, VIn <: HList, Bd, M <: MethodTy
   implicit def prepend: Prepend.Aux[ROut, Bd :: HNil, POut]
   implicit def eqProof: POut =:= VIn
 
-  protected def execute(input: ROut, body: Bd, endpoint: Endpoint[El, KIn, VIn, M, (BodyType[Bd], ROut), F, FOut]): F[FOut] = 
+  protected def execute(input: ROut, body: Bd, endpoint: Endpoint[El, KIn, VIn, M, (BodyType[Bd], ROut), F, FOut]): F[Result[FOut]] = 
     endpoint.apply(input :+ body)
 }

--- a/server/src/main/scala/typedapi/server/EndpointResult.scala
+++ b/server/src/main/scala/typedapi/server/EndpointResult.scala
@@ -1,0 +1,84 @@
+package typedapi.server
+
+final case class SuccessCode(statusCode: Int) extends AnyVal
+final case class ErrorCode(statusCode: Int) extends AnyVal
+
+final case class HttpError(code: ErrorCode, message: String)
+
+trait EndpointResult {
+
+  type Result[A] = Either[HttpError, (SuccessCode, A)]
+
+  final def successWith[A](code: SuccessCode)(a: A): Result[A] = Right(code -> a)
+  final def success[A](a: A): Result[A] = successWith(Ok)(a)
+
+  final val Continue           = SuccessCode(100)
+  final val SwitchingProtocols = SuccessCode(101)
+  final val Processing         = SuccessCode(102)
+
+  final val Ok                          = SuccessCode(200)
+  final val Created                     = SuccessCode(201)
+  final val Accepted                    = SuccessCode(202)
+  final val NonAuthoritativeInformation = SuccessCode(203)
+  final val NoContent                   = SuccessCode(204)
+  final val ResetContent                = SuccessCode(205)
+  final val PartialContent              = SuccessCode(206)
+  final val MultiStatus                 = SuccessCode(207)
+  final val AlreadyReported             = SuccessCode(208)
+  final val IMUsed                      = SuccessCode(226)
+
+  final val MultipleChoices   = SuccessCode(300)
+  final val MovedPermanently  = SuccessCode(301)
+  final val Found             = SuccessCode(302)
+  final val SeeOther          = SuccessCode(303)
+  final val NotModified       = SuccessCode(304)
+  final val UseProxy          = SuccessCode(305)
+  final val TemporaryRedirect = SuccessCode(307)
+  final val PermanentRedirect = SuccessCode(308)
+
+  final def errorWith[A](code: ErrorCode, message: String): Result[A] = Left(HttpError(code, message))
+
+  final val BadRequest                      = ErrorCode(400)
+  final val Unauthorized                    = ErrorCode(401)
+  final val PaymentRequired                 = ErrorCode(402)
+  final val Forbidden                       = ErrorCode(403)
+  final val NotFound                        = ErrorCode(404)
+  final val MethodNotAllowed                = ErrorCode(405)
+  final val NotAcceptable                   = ErrorCode(406)
+  final val ProxyAuthenticationRequired     = ErrorCode(407)
+  final val RequestTimeout                  = ErrorCode(408)
+  final val Conflict                        = ErrorCode(409)
+  final val Gone                            = ErrorCode(410)
+  final val LengthRequired                  = ErrorCode(411)
+  final val PreconditionFailed              = ErrorCode(412)
+  final val PayloadTooLarge                 = ErrorCode(413)
+  final val RequestURITooLong               = ErrorCode(414)
+  final val UnsupportedMediaType            = ErrorCode(415)
+  final val RequestedRangeNotSatisfiable    = ErrorCode(416)
+  final val ExpectationFailed               = ErrorCode(417)
+  final val ImAteapot                       = ErrorCode(418)
+  final val MisdirectedRequest              = ErrorCode(421)
+  final val UnprocessableEntity             = ErrorCode(422)
+  final val Locked                          = ErrorCode(423)
+  final val FailedDependency                = ErrorCode(424)
+  final val UpgradeRequired                 = ErrorCode(426)
+  final val PreconditionRequired            = ErrorCode(428)
+  final val TooManyRequests                 = ErrorCode(429)
+  final val RequestHeaderFieldsTooLarge     = ErrorCode(431)
+  final val ConnectionClosedWithoutResult = ErrorCode(444)
+  final val UnavailableForLegalReasons      = ErrorCode(451)
+  final val ClientClosedRequest             = ErrorCode(499)
+
+  final val InternalServerError           = ErrorCode(500)
+  final val NotImplemented                = ErrorCode(501)
+  final val BadGateway                    = ErrorCode(502)
+  final val ServiceUnavailable            = ErrorCode(503)
+  final val GatewayTimeout                = ErrorCode(504)
+  final val HTTPVersionNotSupported       = ErrorCode(505)
+  final val VariantAlsoNegotiates         = ErrorCode(506)
+  final val InsufficientStorage           = ErrorCode(507)
+  final val LoopDetected                  = ErrorCode(508)
+  final val NotExtended                   = ErrorCode(510)
+  final val NetworkAuthenticationRequired = ErrorCode(511)
+  final val NetworkConnectTimeoutError    = ErrorCode(599)
+}

--- a/server/src/main/scala/typedapi/server/package.scala
+++ b/server/src/main/scala/typedapi/server/package.scala
@@ -9,7 +9,8 @@ import scala.language.higherKinds
 package object server extends TypeLevelFoldLeftLowPrio 
                       with TypeLevelFoldLeftListLowPrio 
                       with WitnessToStringLowPrio
-                      with ApiTransformer {
+                      with ApiTransformer
+                      with EndpointResult {
 
   def derive[F[_]]: ExecutableDerivation[F] = new ExecutableDerivation[F]
 

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -16,8 +16,8 @@ final class ApiToEndpointLinkSpec extends Specification {
                     Server.Send('foo, 'bar) :> Server.Match[String]("hi") :>
                     Get[Json, List[Foo]]
 
-    val endpoint0 = derive[Option](Api).from((name, limit, hi) => Some(List(Foo(name)).take(limit)))
-    endpoint0("john" :: 10 :: Set("whats", "up") :: HNil) === Some(List(Foo("john")))
+    val endpoint0 = derive[Option](Api).from((name, limit, hi) => Some(successWith(Ok)(List(Foo(name)).take(limit))))
+    endpoint0("john" :: 10 :: Set("whats", "up") :: HNil) === Some(Right(Ok -> List(Foo("john"))))
     endpoint0.headers == Map("foo" -> "bar")
     endpoint0.method == "GET"
   }


### PR DESCRIPTION
#36 

The server dsl new enables user to set the status code of a response:

```Scala
val Api = := :> "user" :> Segment[Int]("id") :> Get[Json, User]

derive[IO](Api).from { id => 
  val user: Option[User] = // find user

  user.fold(errorWith(NotFound, s"couldn't find user $id") { user => success(user) }
}
```

It adds `successWith[A](code: SuccessCode)(a: A)` and `errorWith(code: ErrorCode, msg: String)` with an additional `success[A](a: A)` which simply returns *200*.