### PR TITLE
Client: send header maps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ val `compiler-2.11` = Seq(
 
 lazy val commonSettings = Seq(
   organization  := "com.github.pheymann",
-  version       := "0.2.0-RC2",
+  version       := "0.2.0-RC3",
   crossScalaVersions := Seq("2.11.11", "2.12.4"),
   scalaVersion       := "2.12.4",
   scalacOptions      ++= { CrossVersion.partialVersion(scalaVersion.value) match {

--- a/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
+++ b/client/src/main/scala/typedapi/client/RequestDataBuilder.scala
@@ -117,6 +117,18 @@ trait RequestDataBuilderLowPrio {
       }
     }
 
+  implicit def clientHeaderCollInputCompiler[V, T <: HList, KIn <: HList, VIn <: HList, M <: MethodType, O]
+      (implicit compiler: RequestDataBuilder[T, KIn, VIn, M, O]) =
+    new RequestDataBuilder[ClientHeaderCollInput :: T, KIn, Map[String, V] :: VIn, M, O] {
+      type Out = compiler.Out
+
+      def apply(inputs: Map[String, V] :: VIn, uri: Builder[String, List[String]], queries: Map[String, List[String]], headers: Map[String, String]): Out = {
+        val coll = inputs.head.mapValues(_.toString)
+
+        compiler(inputs.tail, uri, queries, coll ++ headers)
+      }
+    }
+
   type Data             = List[String] :: Map[String, List[String]] :: Map[String, String] :: HNil
   type DataWithBody[Bd] = List[String] :: Map[String, List[String]] :: Map[String, String] :: Bd :: HNil
 

--- a/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
+++ b/client/src/test/scala/typedapi/client/RequestDataBuilderSpec.scala
@@ -68,6 +68,8 @@ final class RequestDataBuilderSpec extends Specification {
         api4(0).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "0"))
         val api5 = derive(:= :> Client.Header('i0, 'i1) :> Get[Json, ReqInput])
         api5().run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "i0" -> "i1"))
+        val api6 = derive(:= :> Client.Coll[Int] :> Get[Json, ReqInput])
+        api6(Map("hello" -> 5)).run[Id](cm) === ReqInput("GET", Nil, Map(), Map("Accept" -> "application/json", "hello" -> "5"))
       }
 
       "ignore server elements" >> {

--- a/docs/ApiDefinition.md
+++ b/docs/ApiDefinition.md
@@ -179,7 +179,19 @@ You have to send static headers from the client-side but not server side? Here y
 := :> "header" :> "client" :> "fixed" :> Client.Header("consumer", "me") :> Get[Json, A]
 
 // function
-api(Get[Json, A], Root / "header" / "client", headers = Headers.client("consumer", "me"))
+api(Get[Json, A], Root / "header" / "client" / "fixed", headers = Headers.client("consumer", "me"))
+```
+
+#### Client-Side: Header collections
+You can send header collections (`Map[String, V]`) as a single argument:
+
+```Scala
+// GET /header/client/coll {headers: a:b:...}
+//dsl
+:= :> "header" :> "client" :> "coll" :> Client.Coll[Int] :> Get[Json, A]
+
+//function
+api(Get[Json, A], Root / "header" / "client" / "coll", headers = Headers.clientColl[Int])
 ```
 
 #### Server-Side: send Headers

--- a/docs/example/build.sbt
+++ b/docs/example/build.sbt
@@ -1,5 +1,5 @@
 
-val typedapiVersion = "0.2.0-RC2"
+val typedapiVersion = "0.2.0-RC3"
 val http4sVersion   = "0.18.0"
 
 val commonSettings = Seq(

--- a/docs/example/client-js/src/main/scala/Client.scala
+++ b/docs/example/client-js/src/main/scala/Client.scala
@@ -23,7 +23,7 @@ object Client {
   ))
   implicit val encoder = typedapi.util.Encoder[Future, User](user => Future.successful(user.asJson.noSpaces))
 
-  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, matches) = deriveAll(FromDsl.MyApi)
+  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, coll, matches) = deriveAll(FromDsl.MyApi)
 
   def main(args: Array[String]): Unit = {
     val cm = ClientManager(Ajax, "http://localhost", 9000)

--- a/docs/example/client-jvm/src/main/scala/Client.scala
+++ b/docs/example/client-jvm/src/main/scala/Client.scala
@@ -10,7 +10,7 @@ object Client {
   implicit val decoder = jsonOf[IO, User]
   implicit val encoder = jsonEncoderOf[IO, User]
 
-  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, matches) = deriveAll(FromDsl.MyApi)
+  val (get, put, post, delete, path, putBody, segment, search, header, fixed, client, coll, matches) = deriveAll(FromDsl.MyApi)
 
   def main(args: Array[String]): Unit = {
     import User._

--- a/docs/example/server/src/main/scala/Server.scala
+++ b/docs/example/server/src/main/scala/Server.scala
@@ -24,9 +24,24 @@ object Server {
   val header: String => IO[Result[User]] = consumer => IO.pure(success(User("found: " + consumer, 42)))
   val fixed: () => IO[Result[User]] = get
   val client: () => IO[Result[User]] = get
-  val matching: Set[String] => IO[Result[User]] = matches => IO.pure(success(User(matches.mkString(""), 42)))
+  val coll: () => IO[Result[User]] = get
+  val matching: Map[String, String] => IO[Result[User]] = matches => IO.pure(success(User(matches.mkString(","), 42)))
 
-  val endpoints = deriveAll[IO](FromDefinition.MyApi).from(get, put, post, delete, path, putBody, segment, search, header, fixed, client, matching)
+  val endpoints = deriveAll[IO](FromDefinition.MyApi).from(
+    get, 
+    put, 
+    post, 
+    delete, 
+    path, 
+    putBody, 
+    segment, 
+    search, 
+    header, 
+    fixed, 
+    client, 
+    coll, 
+    matching
+  )
 
   def main(args: Array[String]): Unit = {
     import org.http4s.server.blaze.BlazeBuilder

--- a/docs/example/shared/src/main/scala/Apis.scala
+++ b/docs/example/shared/src/main/scala/Apis.scala
@@ -28,6 +28,7 @@ object FromDsl {
     (:= :> "header" :> Header[String]("consumer") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     (:= :> "header" :> "fixed" :> Header("consumer", "me") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     (:= :> "header" :> "client" :> Client.Header("client", "me") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "client" :> "coll" :> Client.Coll[Int] :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User]) :|:
     (:= :> "header" :> "server" :> Server.Match[String]("Control-") :> Server.Send("Access-Control-Allow-Origin", "*") :> Get[Json, User])
 }
 
@@ -56,5 +57,6 @@ object FromDefinition {
     api(Get[Json, User], Root / "header", headers = Headers.add[String]("consumer").serverSend("Access-Control-Allow-Origin", "*")) :|:
     api(Get[Json, User], Root / "header" / "fixed", headers = Headers.add("consumer", "me").serverSend("Access-Control-Allow-Origin", "*")) :|:
     api(Get[Json, User], Root / "header" / "client", headers = Headers.client("client", "me").serverSend("Access-Control-Allow-Origin", "*")) :|:
+    api(Get[Json, User], Root / "header" / "client" / "coll", headers = Headers.clientColl[Int].serverSend("Access-Control-Allow-Origin", "*")) :|:
     api(Get[Json, User], Root / "header" / "server", headers = Headers.serverMatch[String]("Control-").serverSend("Access-Control-Allow-Origin", "*"))
 }

--- a/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/AkkaHttpClientSupportSpec.scala
@@ -30,7 +30,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
   val server = TestServer.start()
 
   "akka http client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, clColl, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Future](cm) must beEqualTo(User("foo", 27)).awaitFor(timeout)
@@ -46,6 +46,7 @@ final class AkkaHttpClientSupportSpec(implicit ee: ExecutionEnv) extends Specifi
       fixed().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
       clInH("jim").run[Future](cm) must beEqualTo(User("jim", 27)).awaitFor(timeout)
       clFixH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
+      clColl(Map("coll" -> "joe", "collect" -> "jim")).run[Future](cm) must beEqualTo(User("coll: joe,collect: jim", 27)).awaitFor(timeout)
       serMatchH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
       serSendH().run[Future](cm) must beEqualTo(User("joe", 27)).awaitFor(timeout)
     }

--- a/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/Http4sClientSupportSpec.scala
@@ -18,7 +18,7 @@ final class Http4sClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, clColl, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[IO](cm).unsafeRunSync() === User("foo", 27)
@@ -34,6 +34,7 @@ final class Http4sClientSupportSpec extends Specification {
       fixed().run[IO](cm).unsafeRunSync() === User("joe", 27)
       clInH("jim").run[IO](cm).unsafeRunSync === User("jim", 27)
       clFixH().run[IO](cm).unsafeRunSync() === User("joe", 27)
+      clColl(Map("coll" -> "joe", "collect" -> "jim")).run[IO](cm).unsafeRunSync === User("coll: joe,collect: jim", 27)
       serMatchH().run[IO](cm).unsafeRunSync() === User("joe", 27)
       serSendH().run[IO](cm).unsafeRunSync() === User("joe", 27)
     }

--- a/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/ScalajHttpClientSupportSpec.scala
@@ -27,7 +27,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
   val server = TestServer.start()
 
   "http4s client support" >> {
-    val (p, s, q, header, fixed, clInH, clFixH, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
+    val (p, s, q, header, fixed, clInH, clFixH, clColl, serMatchH, serSendH, m0, m1, m2, m3, m4, m5, _, _, _) = deriveAll(Api)
 
     "paths and segments" >> {
       p().run[Blocking](cm) === Right(User("foo", 27))
@@ -43,6 +43,7 @@ final class ScalajHttpClientSupportSpec extends Specification {
       fixed().run[Blocking](cm) === Right(User("joe", 27))
       clInH("jim").run[Blocking](cm) === Right(User("jim", 27))
       clFixH().run[Blocking](cm) === Right(User("joe", 27))
+      clColl(Map("coll" -> "joe", "collect" -> "jim")).run[Blocking](cm) === Right(User("collect: jim,coll: joe", 27))
       serMatchH().run[Blocking](cm) === Right(User("joe", 27))
       serSendH().run[Blocking](cm) === Right(User("joe", 27))
     }

--- a/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/client/TestServer.scala
@@ -50,6 +50,15 @@ object TestServer {
 
       Ok(User("joe", 27))
 
+    case req @ GET -> Root / "header" / "client" / "coll" =>
+      val headers = req.headers.toList
+      val values  = headers.filter(_.name.value.contains("coll"))
+
+      if (values.isEmpty)
+        throw new IllegalArgumentException("no header collection ")
+
+      Ok(User(values.mkString(","), 27))
+
     case req @ GET -> Root / "header" / "input" / "client" =>
       val headers = req.headers.toList
       val value   = headers.find(_.name.value == "Hello").get.value

--- a/http-support-tests/src/test/scala/http/support/tests/package.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/package.scala
@@ -12,6 +12,7 @@ package object tests {
     (:= :> "header" :> "fixed" :> Header("Hello", "*") :> Get[Json, User]) :|:
     (:= :> "header" :> "input" :> "client" :> Client.Header[String]("Hello") :> Get[Json, User]) :|:
     (:= :> "header" :> "client" :> Client.Header("Hello", "*") :> Get[Json, User]) :|:
+    (:= :> "header" :> "client" :> "coll" :> Client.Coll[String] :> Get[Json, User]) :|:
     (:= :> "header" :> "server" :> "match" :> Server.Match[String]("test") :> Get[Json, User]) :|:
     (:= :> "header" :> "server" :> "send" :> Server.Send("Hello", "*") :> Get[Json, User]) :|:
     (:= :> Get[Json, User]) :|:

--- a/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/AkkaHttpServerSupportSpec.scala
@@ -24,7 +24,27 @@ final class AkkaHttpServerSupportSpec(implicit ee: ExecutionEnv) extends ServerS
 
   import system.dispatcher
 
-  val endpoints = deriveAll[Future](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete, code200, code400, code500)
+  val endpoints = deriveAll[Future](Api).from(
+    path, 
+    segment, 
+    query, 
+    header, 
+    fixed, 
+    input, 
+    clientHdr,
+    coll,
+    matching, 
+    send, 
+    get, 
+    put, 
+    putB, 
+    post, 
+    postB, 
+    delete, 
+    code200, 
+    code400, 
+    code500
+  )
   val sm        = ServerManager(Http(), "localhost", 9000)
   val server    = mount(sm, endpoints)
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/Http4sServerSupportSpec.scala
@@ -10,7 +10,27 @@ final class Http4sServerSupportSpec extends ServerSupportSpec[IO] {
 
   import UserCoding._
 
-  val endpoints = deriveAll[IO](Api).from(path, segment, query, header, fixed, fixed, fixed, matching, fixed, get, put, putB, post, postB, delete, code200, code400, code500)
+  val endpoints = deriveAll[IO](Api).from(
+    path, 
+    segment, 
+    query, 
+    header, 
+    fixed, 
+    input, 
+    clientHdr,
+    coll,
+    matching, 
+    send, 
+    get, 
+    put, 
+    putB, 
+    post, 
+    postB, 
+    delete, 
+    code200, 
+    code400, 
+    code500
+  )
   val sm        = ServerManager(BlazeBuilder[IO], "localhost", 9000)
   val server    = mount(sm, endpoints).unsafeRunSync()
 

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -22,12 +22,12 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
     import UserCoding._
 
     "paths and segments" >> {
-      client.expect[User](s"http://localhost:$port/path").unsafeRunSync() === User("joe", 27)
+      client.expect[User](s"http://localhost:$port/path").unsafeRunSync() === User("path", 27)
       client.expect[User](s"http://localhost:$port/segment/jim").unsafeRunSync() === User("jim", 27)
     }
 
     "queries" >> {
-      client.expect[User](s"http://localhost:$port/query?age=42").unsafeRunSync() === User("joe", 42)
+      client.expect[User](s"http://localhost:$port/query?age=42").unsafeRunSync() === User("query", 42)
     }
 
     "headers" >> {
@@ -35,20 +35,20 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
         method = GET,
         uri = Uri.fromString(s"http://localhost:$port/header").right.get,
         headers = Headers(Header("age", "42"))
-      )).unsafeRunSync() === User("joe", 42)
+      )).unsafeRunSync() === User("header", 42)
       client.expect[User](Request[IO](
         method = GET,
         uri = Uri.fromString(s"http://localhost:$port/header/fixed").right.get,
         headers = Headers(Header("Hello", "*"))
-      )).unsafeRunSync() === User("joe", 27)
+      )).unsafeRunSync() === User("fixed", 27)
       client.expect[User](Request[IO](
         method = GET,
         uri = Uri.fromString(s"http://localhost:$port/header/client").right.get
-      )).unsafeRunSync() === User("joe", 27)
+      )).unsafeRunSync() === User("client header", 27)
       client.expect[User](Request[IO](
         method = GET,
         uri = Uri.fromString(s"http://localhost:$port/header/input/client").right.get
-      )).unsafeRunSync() === User("joe", 27)
+      )).unsafeRunSync() === User("input", 27)
       client.fetch[Option[Header]](
         Request[IO](
           method = GET,
@@ -78,12 +78,12 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
     }
 
     "methods" >> {
-      client.expect[User](s"http://localhost:$port/").unsafeRunSync() === User("joe", 27)
-      client.expect[User](PUT(Uri.fromString(s"http://localhost:$port/").right.get)).unsafeRunSync() === User("joe", 27)
+      client.expect[User](s"http://localhost:$port/").unsafeRunSync() === User("get", 27)
+      client.expect[User](PUT(Uri.fromString(s"http://localhost:$port/").right.get)).unsafeRunSync() === User("put", 27)
       client.expect[User](PUT(Uri.fromString(s"http://localhost:$port/body").right.get, User("joe", 27))).unsafeRunSync() === User("joe", 27)
-      client.expect[User](POST(Uri.fromString(s"http://localhost:$port/").right.get)).unsafeRunSync() === User("joe", 27)
+      client.expect[User](POST(Uri.fromString(s"http://localhost:$port/").right.get)).unsafeRunSync() === User("post", 27)
       client.expect[User](POST(Uri.fromString(s"http://localhost:$port/body").right.get, User("joe", 27))).unsafeRunSync() === User("joe", 27)
-      client.expect[User](DELETE(Uri.fromString(s"http://localhost:$port/?reasons=because").right.get)).unsafeRunSync() === User("joe", 27)
+      client.expect[User](DELETE(Uri.fromString(s"http://localhost:$port/?reasons=because").right.get)).unsafeRunSync() === User("because", 27)
     }
 
     "status codes" >> {
@@ -93,20 +93,23 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
     }
   }
 
-  val path: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val path: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("path", 27)))
   val segment: String => F[Result[User]] = name => Applicative[F].pure(successWith(Ok)(User(name, 27)))
-  val query: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
-  val header: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
-  val fixed: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val query: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("query", age)))
+  val header: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("header", age)))
+  val fixed: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("fixed", 27)))
+  val input: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("input", 27)))
+  val clientHdr: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("client header", 27)))
+  val coll: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("coll", 27)))
   val matching: Map[String, String] => F[Result[User]] = matches => Applicative[F].pure(successWith(Ok)(User(matches.mkString(","), 27)))
-  val get: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
-  val put: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val send: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("send", 27)))
+  val get: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("get", 27)))
+  val put: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("put", 27)))
   val putB: User => F[Result[User]] = user => Applicative[F].pure(successWith(Ok)(user))
-  val post: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+  val post: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("post", 27)))
   val postB: User => F[Result[User]] = user => Applicative[F].pure(successWith(Ok)(user))
   val delete: List[String] => F[Result[User]] = reasons => {
-    println(reasons)
-    Applicative[F].pure(successWith(Ok)(User("joe", 27)))
+    Applicative[F].pure(successWith(Ok)(User(reasons.mkString(","), 27)))
   }
   val code200: () => F[Result[String]] = () => Applicative[F].pure(successWith(Ok)(""))
   val code400: () => F[Result[String]] = () => Applicative[F].pure(errorWith(BadRequest, "meh"))

--- a/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
+++ b/http-support-tests/src/test/scala/http/support/tests/server/ServerSupportSpec.scala
@@ -63,7 +63,7 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
         method = GET,
         uri = Uri.fromString(s"http://localhost:$port/header/server/match").right.get,
         headers = Headers(Header("test", "foo"), Header("testy", "bar"), Header("meh", "NONO"))
-      )).unsafeRunSync() === User("foobar", 27)
+      )).unsafeRunSync() === User("test -> foo,testy -> bar", 27)
       client.fetch[Option[Header]](
         Request[IO](
           method = OPTIONS,
@@ -98,7 +98,7 @@ abstract class ServerSupportSpec[F[_]: Applicative] extends Specification {
   val query: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
   val header: Int => F[Result[User]] = age => Applicative[F].pure(successWith(Ok)(User("joe", age)))
   val fixed: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
-  val matching: Set[String] => F[Result[User]] = matches => Applicative[F].pure(successWith(Ok)(User(matches.mkString(""), 27)))
+  val matching: Map[String, String] => F[Result[User]] = matches => Applicative[F].pure(successWith(Ok)(User(matches.mkString(","), 27)))
   val get: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
   val put: () => F[Result[User]] = () => Applicative[F].pure(successWith(Ok)(User("joe", 27)))
   val putB: User => F[Result[User]] = user => Applicative[F].pure(successWith(Ok)(user))

--- a/server/src/main/scala/typedapi/server/FilterClientElements.scala
+++ b/server/src/main/scala/typedapi/server/FilterClientElements.scala
@@ -1,6 +1,6 @@
 package typedapi.server
 
-import typedapi.shared.{ClientHeaderElement, ClientHeaderParam}
+import typedapi.shared.{ClientHeaderElement, ClientHeaderParam, ClientHeaderCollParam}
 import shapeless._
 
 sealed trait FilterClientElements[H <: HList] {
@@ -28,6 +28,10 @@ object FilterClientElements extends FilterClientElementsLowPrio {
   }
 
   implicit def filterClientParam[K, V, T <: HList](implicit next: FilterClientElements[T]) = new FilterClientElements[ClientHeaderParam[K, V] :: T] {
+    type Out = next.Out
+  }
+
+  implicit def filterClientCollParam[V, T <: HList](implicit next: FilterClientElements[T]) = new FilterClientElements[ClientHeaderCollParam[V] :: T] {
     type Out = next.Out
   }
 }

--- a/server/src/main/scala/typedapi/server/RouteExtractor.scala
+++ b/server/src/main/scala/typedapi/server/RouteExtractor.scala
@@ -192,17 +192,17 @@ trait RouteExtractorMediumPrio extends RouteExtractorLowPrio {
     }
 
   implicit def serverHeaderMatchExtractor[El <: HList, K, V, KIn <: HList, VIn <: HList, M <: MethodType, EIn <: HList]
-      (implicit wit: Witness.Aux[K], show: WitnessToString[K], value: ValueExtractor[V], next: RouteExtractor[El, KIn, VIn, M, shapeless.::[Set[V], EIn]]) =
-    new RouteExtractor[shapeless.::[ServerHeaderMatchInput, El], shapeless.::[K, KIn], shapeless.::[Set[V], VIn], M, EIn] {
+      (implicit wit: Witness.Aux[K], show: WitnessToString[K], value: ValueExtractor[V], next: RouteExtractor[El, KIn, VIn, M, shapeless.::[Map[String, V], EIn]]) =
+    new RouteExtractor[shapeless.::[ServerHeaderMatchInput, El], shapeless.::[K, KIn], shapeless.::[Map[String, V], VIn], M, EIn] {
       type Out = next.Out
 
       def apply(request: EndpointRequest, inAgg: EIn): Extract[Out] = checkEmptyPath(request) { req =>
         val key      = show.show(wit.value).toLowerCase
-        val matchesE = req.headers.foldLeft[Either[ExtractionError, Set[V]]](Right(Set.empty)) { 
+        val matchesE = req.headers.foldLeft[Either[ExtractionError, Map[String, V]]](Right(Map.empty)) { 
           case (Right(agg), (k, raw)) =>
             if (k.contains(key)) {
-              value(raw).fold(BadRequestE[Set[V]](s"header '$k' has not type ${value.typeDesc}")) { v =>
-                Right(agg + v)
+              value(raw).fold(BadRequestE[Map[String, V]](s"header '$k' has not type ${value.typeDesc}")) { v =>
+                Right(agg + (k -> v))
               }
             }
             else

--- a/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
+++ b/server/src/test/scala/typedapi/server/ApiToEndpointLinkSpec.scala
@@ -17,7 +17,7 @@ final class ApiToEndpointLinkSpec extends Specification {
                     Get[Json, List[Foo]]
 
     val endpoint0 = derive[Option](Api).from((name, limit, hi) => Some(successWith(Ok)(List(Foo(name)).take(limit))))
-    endpoint0("john" :: 10 :: Set("whats", "up") :: HNil) === Some(Right(Ok -> List(Foo("john"))))
+    endpoint0("john" :: 10 :: Map("hi" -> "whats", "hi-ho" -> "up") :: HNil) === Some(Right(Ok -> List(Foo("john"))))
     endpoint0.headers == Map("foo" -> "bar")
     endpoint0.method == "GET"
   }

--- a/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
+++ b/server/src/test/scala/typedapi/server/RouteExtractorSpec.scala
@@ -79,9 +79,9 @@ final class RouteExtractorSpec extends Specification {
 
       val ext6 = extract(:= :> "foo" :> Server.Match[Int]("age") :> Get[Json, Foo])
 
-      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), HNil) === Right(Set(0) :: HNil)
-      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age-and-what-not" -> "0")), HNil) === Right(Set(0) :: HNil)
-      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("nope" -> "0")), HNil) === Right(Set.empty :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age" -> "0")), HNil) === Right(Map("age" ->0) :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age-and-what-not" -> "0")), HNil) === Right(Map("age-and-what-not" -> 0) :: HNil)
+      ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("nope" -> "0")), HNil) === Right(Map.empty :: HNil)
       ext6(EndpointRequest("GET", List("foo"), Map.empty, Map("age-" -> "hello")), HNil) === RouteExtractor.BadRequestE("header 'age-' has not type Int")
     }
 

--- a/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
+++ b/shared/src/main/scala/typedapi/dsl/ApiDsl.scala
@@ -22,8 +22,11 @@ sealed trait HeaderOps[H <: HList] {
 
   def :>[K, V](header: TypeCarrier[HeaderParam[K, V]]): InputHeaderCons[HeaderParam[K, V] :: H] = InputHeaderCons()
   def :>[K, V](fixed: TypeCarrier[FixedHeaderElement[K, V]]): FixedHeaderCons[FixedHeaderElement[K, V] :: H] = FixedHeaderCons()
+
   def :>[K, V](client: TypeCarrier[ClientHeaderElement[K, V]]): ClientHeaderElCons[ClientHeaderElement[K, V] :: H] = ClientHeaderElCons()
   def :>[K, V](client: TypeCarrier[ClientHeaderParam[K, V]]): ClientHeaderParamCons[ClientHeaderParam[K, V] :: H] = ClientHeaderParamCons()
+  def :>[V](client: TypeCarrier[ClientHeaderCollParam[V]]): ClientHeaderCollParamCons[ClientHeaderCollParam[V] :: H] = ClientHeaderCollParamCons()
+
   def :>[K, V](server: TypeCarrier[ServerHeaderMatchParam[K, V]]): ServerHeaderMatchParamCons[ServerHeaderMatchParam[K, V] :: H] = ServerHeaderMatchParamCons()
   def :>[K, V](server: TypeCarrier[ServerHeaderSendElement[K, V]]): ServerHeaderSendElCons[ServerHeaderSendElement[K, V] :: H] = ServerHeaderSendElCons()
 }
@@ -59,6 +62,7 @@ final case class InputHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class FixedHeaderCons[H <: HList]() extends HeaderCons[H]
 final case class ClientHeaderElCons[H <: HList]() extends HeaderCons[H]
 final case class ClientHeaderParamCons[H <: HList]() extends HeaderCons[H]
+final case class ClientHeaderCollParamCons[H <: HList]() extends HeaderCons[H]
 final case class ServerHeaderMatchParamCons[H <: HList]() extends HeaderCons[H]
 final case class ServerHeaderSendElCons[H <: HList]() extends HeaderCons[H]
 

--- a/shared/src/main/scala/typedapi/dsl/package.scala
+++ b/shared/src/main/scala/typedapi/dsl/package.scala
@@ -15,6 +15,7 @@ package object dsl extends MethodToReqBodyLowPrio with MethodToStringLowPrio wit
 
     def Header    = new PairTypeFromWitnesses[ClientHeaderElement]
     def Header[V] = new PairTypeFromWitnessKey[ClientHeaderParam, V]
+    def Coll[V]   = TypeCarrier[ClientHeaderCollParam[V]]()
   }
 
   object Server {

--- a/shared/src/main/scala/typedapi/shared/ApiElement.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiElement.scala
@@ -22,6 +22,8 @@ sealed trait FixedHeaderElement[K, V] extends ApiElement
 sealed trait ClientHeaderElement[K, V] extends ApiElement
 /** Type-container providing the name (singleton) and value type for a header parameter only used for the client. */
 sealed trait ClientHeaderParam[K, V] extends ApiElement
+/** Type-container providing a collection of headers (Map[String, V]) only used for the client. */
+sealed trait ClientHeaderCollParam[V] extends ApiElement
 /** Type-container providing the name (singleton) and value type for a static header element sent by server. */
 sealed trait ServerHeaderSendElement[K, V] extends ApiElement
 /** Type-container providing the name (singleton) and value type describing a sub-string headers have to match only used for the server. */

--- a/shared/src/main/scala/typedapi/shared/ApiList.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiList.scala
@@ -35,7 +35,9 @@ final case class HeaderListBuilder[H <: HList]() {
   }
   def client[V]: ClientWitnessDerivation[V] = new ClientWitnessDerivation[V]
   
-def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
+  def client[K, V](kWit: Witness.Lt[K], vWit: Witness.Lt[V]): HeaderListBuilder[ClientHeaderElement[K, V] :: H] = HeaderListBuilder()
+
+  def clientColl[V]: HeaderListBuilder[ClientHeaderCollParam[V] :: H] = HeaderListBuilder()
 
   final class ServerMatchWitnessDerivation[V] {
     def apply[K](wit: Witness.Lt[K]): HeaderListBuilder[ServerHeaderMatchParam[K, V] :: H] = HeaderListBuilder()

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -86,7 +86,7 @@ trait ApiTransformer {
     at[ServerHeaderSendElement[K, V], (El, KIn, VIn, M, Out), (ServerHeaderSend[K, V] :: El, KIn, VIn, M, Out)]
 
   implicit def serverHeaderMatchParamTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
-    at[ServerHeaderMatchParam[K, V], (El, KIn, VIn, M, Out), (ServerHeaderMatchInput :: El, K :: KIn, Set[V] :: VIn, M, Out)]
+    at[ServerHeaderMatchParam[K, V], (El, KIn, VIn, M, Out), (ServerHeaderMatchInput :: El, K :: KIn, Map[String, V] :: VIn, M, Out)]
 
   implicit def getTransformer[MT <: MediaType, A] = at[GetElement[MT, A], Unit, (HNil, HNil, HNil, GetCall, FieldType[MT, A])]
 

--- a/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
+++ b/shared/src/main/scala/typedapi/shared/ApiTransformer.scala
@@ -14,6 +14,7 @@ sealed trait HeaderInput extends ApiOp
 sealed trait FixedHeader[K, V] extends ApiOp
 sealed trait ClientHeader[K, V] extends ApiOp
 sealed trait ClientHeaderInput extends ApiOp
+sealed trait ClientHeaderCollInput extends ApiOp
 sealed trait ServerHeaderSend[K, V] extends ApiOp
 sealed trait ServerHeaderMatchInput extends ApiOp
 
@@ -81,6 +82,9 @@ trait ApiTransformer {
 
   implicit def clientHeaderParamTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[ClientHeaderParam[K, V], (El, KIn, VIn, M, Out), (ClientHeaderInput :: El, K :: KIn, V :: VIn, M, Out)]
+
+  implicit def clientHeaderCollParamTransformer[V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
+    at[ClientHeaderCollParam[V], (El, KIn, VIn, M, Out), (ClientHeaderCollInput :: El, KIn, Map[String, V] :: VIn, M, Out)]
 
   implicit def serverHeaderSendElementTransformer[K, V, El <: HList, KIn <: HList, VIn <: HList, M <: MethodType, Out] = 
     at[ServerHeaderSendElement[K, V], (El, KIn, VIn, M, Out), (ServerHeaderSend[K, V] :: El, KIn, VIn, M, Out)]

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -38,6 +38,7 @@ object ApiDefinitionSpec {
   testCompile(Headers client[String](fooW))[ClientHeaderParam[fooW.T, String] :: HNil]
   testCompile(Headers serverSend(fooW, testW))[ServerHeaderSendElement[fooW.T, testW.T] :: HNil]
   testCompile(Headers serverMatch[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: HNil]
+  testCompile(Headers serverMatch[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: HNil]
 
   // methods
   testCompile(api(Get[Json, Foo]))[GetElement[`Application/json`, Foo] :: HNil]

--- a/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
+++ b/shared/src/test/scala/typedapi/ApiDefinitionSpec.scala
@@ -36,6 +36,7 @@ object ApiDefinitionSpec {
   testCompile(Headers add(fooW, testW))[FixedHeaderElement[fooW.T, testW.T] :: HNil]
   testCompile(Headers client(fooW, testW))[ClientHeaderElement[fooW.T, testW.T] :: HNil]
   testCompile(Headers client[String](fooW))[ClientHeaderParam[fooW.T, String] :: HNil]
+  testCompile(Headers.clientColl[String])[ClientHeaderCollParam[String] :: HNil]
   testCompile(Headers serverSend(fooW, testW))[ServerHeaderSendElement[fooW.T, testW.T] :: HNil]
   testCompile(Headers serverMatch[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: HNil]
   testCompile(Headers serverMatch[String](fooW))[ServerHeaderMatchParam[fooW.T, String] :: HNil]

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -30,6 +30,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderParam[fooW.T, String] :: HNil, (ClientHeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderElement[fooW.T, barW.T] :: HNil, (ClientHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ClientHeaderCollParam[Int] :: HNil, (ClientHeaderCollInput :: HNil, HNil, Map[String, Int] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ServerHeaderMatchParam[fooW.T, String] :: HNil, (ServerHeaderMatchInput :: HNil, fooW.T :: HNil, Map[String, String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ServerHeaderSendElement[fooW.T, barW.T] :: HNil, (ServerHeaderSend[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 

--- a/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
+++ b/shared/src/test/scala/typedapi/shared/ApiTransformerSpec.scala
@@ -30,7 +30,7 @@ final class ApiTransformerSpec extends TypeLevelFoldLeftLowPrio with ApiTransfor
   testCompile[GetElement[Json, Foo] :: FixedHeaderElement[fooW.T, barW.T] :: HNil, (FixedHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderParam[fooW.T, String] :: HNil, (ClientHeaderInput :: HNil, fooW.T :: HNil, String :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ClientHeaderElement[fooW.T, barW.T] :: HNil, (ClientHeader[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
-  testCompile[GetElement[Json, Foo] :: ServerHeaderMatchParam[fooW.T, String] :: HNil, (ServerHeaderMatchInput :: HNil, fooW.T :: HNil, Set[String] :: HNil, GetCall, FieldType[Json, Foo])]
+  testCompile[GetElement[Json, Foo] :: ServerHeaderMatchParam[fooW.T, String] :: HNil, (ServerHeaderMatchInput :: HNil, fooW.T :: HNil, Map[String, String] :: HNil, GetCall, FieldType[Json, Foo])]
   testCompile[GetElement[Json, Foo] :: ServerHeaderSendElement[fooW.T, barW.T] :: HNil, (ServerHeaderSend[fooW.T, barW.T] :: HNil, HNil, HNil, GetCall, FieldType[Json, Foo])]
 
   testCompile[


### PR DESCRIPTION
see #35 

This PR introduces header collections (`Map[String, V]`) to the client side:

```Scala
val Api = :> Client.Coll[Int] :> Get[Json, User]

val get = derive(Api)

get(Map("foo" -> 0, "bar" -> 1)).run[IO](cm)
```

As indicated by the `Client` object, this api element is client specific. Therefore, it is not taken into account on the server side. You can use `Server.Match` if you want to extract the headers.